### PR TITLE
[Chore] 코드리뷰에 대한 수정사항 반영 (#5)

### DIFF
--- a/BuddyBuddy.xcodeproj/project.pbxproj
+++ b/BuddyBuddy.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		C0BF428B2CE4721600C5B5B4 /* Differentiator in Frameworks */ = {isa = PBXBuildFile; productRef = C0BF428A2CE4721600C5B5B4 /* Differentiator */; };
 		C0BF428D2CE4721600C5B5B4 /* RxDataSources in Frameworks */ = {isa = PBXBuildFile; productRef = C0BF428C2CE4721600C5B5B4 /* RxDataSources */; };
 		C0BF428F2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BF428E2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift */; };
-		C0BF42912CE4774B00C5B5B4 /* DefaultChannelTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BF42902CE4774B00C5B5B4 /* DefaultChannelTableViewCell.swift */; };
+		C0BF42912CE4774B00C5B5B4 /* ReadChannelTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BF42902CE4774B00C5B5B4 /* ReadChannelTableViewCell.swift */; };
 		C0BF42932CE47A6100C5B5B4 /* UnreadChannelTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BF42922CE47A6100C5B5B4 /* UnreadChannelTableViewCell.swift */; };
 		C0BF42952CE4D71E00C5B5B4 /* ChannelSectionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BF42942CE4D71E00C5B5B4 /* ChannelSectionModel.swift */; };
 		C90827F82CDA64B70096BA0D /* RealmEmpty in Resources */ = {isa = PBXBuildFile; fileRef = C90827F72CDA64B70096BA0D /* RealmEmpty */; };
@@ -141,7 +141,7 @@
 		C0327C7B2CE5870A00AEAEE1 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		C0BF42872CE211BB00C5B5B4 /* ChannelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelView.swift; sourceTree = "<group>"; };
 		C0BF428E2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTitleTableViewCell.swift; sourceTree = "<group>"; };
-		C0BF42902CE4774B00C5B5B4 /* DefaultChannelTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChannelTableViewCell.swift; sourceTree = "<group>"; };
+		C0BF42902CE4774B00C5B5B4 /* ReadChannelTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadChannelTableViewCell.swift; sourceTree = "<group>"; };
 		C0BF42922CE47A6100C5B5B4 /* UnreadChannelTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadChannelTableViewCell.swift; sourceTree = "<group>"; };
 		C0BF42942CE4D71E00C5B5B4 /* ChannelSectionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelSectionModel.swift; sourceTree = "<group>"; };
 		C90827F72CDA64B70096BA0D /* RealmEmpty */ = {isa = PBXFileReference; lastKnownFileType = text; path = RealmEmpty; sourceTree = "<group>"; };
@@ -496,7 +496,7 @@
 			children = (
 				C0BF42872CE211BB00C5B5B4 /* ChannelView.swift */,
 				C0BF428E2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift */,
-				C0BF42902CE4774B00C5B5B4 /* DefaultChannelTableViewCell.swift */,
+				C0BF42902CE4774B00C5B5B4 /* ReadChannelTableViewCell.swift */,
 				C0BF42922CE47A6100C5B5B4 /* UnreadChannelTableViewCell.swift */,
 				C91BBC142CE472CA001EFC70 /* ChannelSettingCell.swift */,
 				C91BBC162CE47F66001EFC70 /* ChannelSettingTopView.swift */,
@@ -1130,7 +1130,7 @@
 				C91BBC072CE37265001EFC70 /* SearchImageType.swift in Sources */,
 				C9F96D672CDD2A5400271295 /* AppDelegate+Register.swift in Sources */,
 				C9F20F442CDB62530043351E /* HomeViewModel.swift in Sources */,
-				C0BF42912CE4774B00C5B5B4 /* DefaultChannelTableViewCell.swift in Sources */,
+				C0BF42912CE4774B00C5B5B4 /* ReadChannelTableViewCell.swift in Sources */,
 				DC213AB22CE484BE00E2A2F7 /* AccessToken.swift in Sources */,
 				C9F20F4C2CDB64070043351E /* SearchViewController.swift in Sources */,
 				C957EA712CE21FD800B62A2A /* SearchItemTableViewCell.swift in Sources */,

--- a/BuddyBuddy.xcodeproj/project.pbxproj
+++ b/BuddyBuddy.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		C0BF42912CE4774B00C5B5B4 /* ReadChannelTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BF42902CE4774B00C5B5B4 /* ReadChannelTableViewCell.swift */; };
 		C0BF42932CE47A6100C5B5B4 /* UnreadChannelTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BF42922CE47A6100C5B5B4 /* UnreadChannelTableViewCell.swift */; };
 		C0BF42952CE4D71E00C5B5B4 /* ChannelSectionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BF42942CE4D71E00C5B5B4 /* ChannelSectionModel.swift */; };
+		C0EA66802CE7227D00401F92 /* ChannelAddTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EA667F2CE7227D00401F92 /* ChannelAddTableViewCell.swift */; };
 		C90827F82CDA64B70096BA0D /* RealmEmpty in Resources */ = {isa = PBXBuildFile; fileRef = C90827F72CDA64B70096BA0D /* RealmEmpty */; };
 		C90827FC2CDA64C80096BA0D /* RepositoryEmpty in Resources */ = {isa = PBXBuildFile; fileRef = C90827FB2CDA64C80096BA0D /* RepositoryEmpty */; };
 		C90827FE2CDA64D30096BA0D /* DTOEmpty in Resources */ = {isa = PBXBuildFile; fileRef = C90827FD2CDA64D30096BA0D /* DTOEmpty */; };
@@ -144,6 +145,7 @@
 		C0BF42902CE4774B00C5B5B4 /* ReadChannelTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadChannelTableViewCell.swift; sourceTree = "<group>"; };
 		C0BF42922CE47A6100C5B5B4 /* UnreadChannelTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadChannelTableViewCell.swift; sourceTree = "<group>"; };
 		C0BF42942CE4D71E00C5B5B4 /* ChannelSectionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelSectionModel.swift; sourceTree = "<group>"; };
+		C0EA667F2CE7227D00401F92 /* ChannelAddTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelAddTableViewCell.swift; sourceTree = "<group>"; };
 		C90827F72CDA64B70096BA0D /* RealmEmpty */ = {isa = PBXFileReference; lastKnownFileType = text; path = RealmEmpty; sourceTree = "<group>"; };
 		C90827FB2CDA64C80096BA0D /* RepositoryEmpty */ = {isa = PBXFileReference; lastKnownFileType = text; path = RepositoryEmpty; sourceTree = "<group>"; };
 		C90827FD2CDA64D30096BA0D /* DTOEmpty */ = {isa = PBXFileReference; lastKnownFileType = text; path = DTOEmpty; sourceTree = "<group>"; };
@@ -504,6 +506,7 @@
 				C91BBC182CE487BA001EFC70 /* ChannelSettingBottomView.swift */,
 				C91BBC202CE4C7A7001EFC70 /* ChannelAdminTableViewCell.swift */,
 				C98363DF2CE59F7E00AC51CA /* ProfileBottomView.swift */,
+				C0EA667F2CE7227D00401F92 /* ChannelAddTableViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1104,6 +1107,7 @@
 				C96C72952CDAF9CA00E0D6CF /* BaseView.swift in Sources */,
 				C9F20F642CDB709A0043351E /* DefaultDMCoordinator.swift in Sources */,
 				C98363DE2CE58AD400AC51CA /* ProfileViewModel.swift in Sources */,
+				C0EA66802CE7227D00401F92 /* ChannelAddTableViewCell.swift in Sources */,
 				C91BBC272CE4E343001EFC70 /* ModalNavigationView.swift in Sources */,
 				C9F20F3C2CDB5FFD0043351E /* TabBarViewController.swift in Sources */,
 				C91BBC172CE47F66001EFC70 /* ChannelSettingTopView.swift in Sources */,

--- a/BuddyBuddy/Domain/Entity/ChannelSectionModel.swift
+++ b/BuddyBuddy/Domain/Entity/ChannelSectionModel.swift
@@ -12,7 +12,7 @@ import RxDataSources
 enum ChannelSectionModel: Equatable {
     case title(item: ChannelItem)
     case list(items: [ChannelItem])
-    case add(item: ChannelItem)
+    case add(items: [ChannelItem])
 }
 
 enum ChannelItem: Equatable {
@@ -37,8 +37,8 @@ extension ChannelSectionModel: SectionModelType {
             return [item]
         case .list(let items):
             return items.map { $0 }
-        case .add(let item):
-            return [item]
+        case .add(let items):
+            return items.map { $0 }
         }
     }
     

--- a/BuddyBuddy/Domain/Entity/ChannelSectionModel.swift
+++ b/BuddyBuddy/Domain/Entity/ChannelSectionModel.swift
@@ -20,7 +20,10 @@ enum ChannelItem: Equatable {
     case channel(Channel)
     case add(AddChannel)
     
-    static func == (lhs: ChannelItem, rhs: ChannelItem) -> Bool {
+    static func == (
+        lhs: ChannelItem,
+        rhs: ChannelItem
+    ) -> Bool {
         return false
     }
 }
@@ -39,7 +42,10 @@ extension ChannelSectionModel: SectionModelType {
         }
     }
     
-    init(original: ChannelSectionModel, items: [ChannelItem]) {
+    init(
+        original: ChannelSectionModel,
+        items: [ChannelItem]
+    ) {
         self = original
     }
 }

--- a/BuddyBuddy/Domain/Entity/ChannelSectionModel.swift
+++ b/BuddyBuddy/Domain/Entity/ChannelSectionModel.swift
@@ -10,15 +10,15 @@ import Foundation
 import RxDataSources
 
 enum ChannelSectionModel: Equatable {
-    case title(items: [ChannelItem])
+    case title(item: ChannelItem)
     case list(items: [ChannelItem])
-    case add(items: [ChannelItem])
+    case add(item: ChannelItem)
 }
 
 enum ChannelItem: Equatable {
     case title(Accordion)
     case channel(Channel)
-    case add(AddChannel)
+    case add(String)
     
     static func == (
         lhs: ChannelItem,
@@ -33,12 +33,12 @@ extension ChannelSectionModel: SectionModelType {
     
     var items: [ChannelItem] {
         switch self {
-        case .title(let items):
-            return items.map { $0 }
+        case .title(let item):
+            return [item]
         case .list(let items):
             return items.map { $0 }
-        case .add(let items):
-            return items.map { $0 }
+        case .add(let item):
+            return [item]
         }
     }
     
@@ -59,9 +59,4 @@ struct Channel {
 enum Accordion: String {
     case arrow = "chevronRight"
     case caret = "chevronDown"
-}
-
-struct AddChannel {
-    let title = "채널추가"
-    let imageString = "plus"
 }

--- a/BuddyBuddy/Presentation/Home/View/ChannelAddTableViewCell.swift
+++ b/BuddyBuddy/Presentation/Home/View/ChannelAddTableViewCell.swift
@@ -35,7 +35,7 @@ final class ChannelAddTableViewCell: BaseTableViewCell {
             make.leading.equalToSuperview().inset(16)
             make.size.equalTo(18)
         }
-        titleLabel.snp.remakeConstraints { make in
+        titleLabel.snp.makeConstraints { make in
             make.verticalEdges.equalToSuperview()
             make.leading.equalTo(iconImgView.snp.trailing).offset(12)
             make.height.equalTo(48)

--- a/BuddyBuddy/Presentation/Home/View/ChannelAddTableViewCell.swift
+++ b/BuddyBuddy/Presentation/Home/View/ChannelAddTableViewCell.swift
@@ -1,0 +1,48 @@
+//
+//  ChannelAddTableViewCell.swift
+//  BuddyBuddy
+//
+//  Created by 아라 on 11/15/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class ChannelAddTableViewCell: BaseTableViewCell {
+    private let iconImgView: UIImageView = {
+        let view = UIImageView()
+        view.tintColor = .gray1
+        view.image = UIImage(systemName: "plus")
+        return view
+    }()
+    private let titleLabel: UILabel = {
+        let view = UILabel()
+        view.font = UIFont.body
+        view.textColor = .gray1
+        return view
+    }()
+    
+    override func setHierarchy() {
+        [iconImgView, titleLabel].forEach {
+            contentView.addSubview($0)
+        }
+    }
+    
+    override func setConstraints() {
+        iconImgView.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview().inset(16)
+            make.size.equalTo(18)
+        }
+        titleLabel.snp.remakeConstraints { make in
+            make.verticalEdges.equalToSuperview()
+            make.leading.equalTo(iconImgView.snp.trailing).offset(12)
+            make.height.equalTo(48)
+        }
+    }
+    
+    func configureCell(title: String) {
+        titleLabel.text = title
+    }
+}

--- a/BuddyBuddy/Presentation/Home/View/ChannelTitleTableViewCell.swift
+++ b/BuddyBuddy/Presentation/Home/View/ChannelTitleTableViewCell.swift
@@ -34,7 +34,6 @@ final class ChannelTitleTableViewCell: BaseTableViewCell {
             make.leading.equalToSuperview().inset(13)
             make.height.equalTo(56)
         }
-        
         chevronImgView.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.trailing.equalToSuperview().inset(13)

--- a/BuddyBuddy/Presentation/Home/View/ChannelView.swift
+++ b/BuddyBuddy/Presentation/Home/View/ChannelView.swift
@@ -65,13 +65,11 @@ final class ChannelView: BaseView {
             make.top.horizontalEdges.equalToSuperview()
             make.height.equalTo(52)
         }
-        
         channelTableView.snp.makeConstraints { make in
             make.top.equalTo(channelBtn.snp.bottom)
             make.horizontalEdges.equalToSuperview()
             make.height.equalTo(0)
         }
-        
         addBtn.snp.makeConstraints { make in
             make.top.equalTo(channelTableView.snp.bottom)
             make.horizontalEdges.equalToSuperview()

--- a/BuddyBuddy/Presentation/Home/View/DefaultChannelTableViewCell.swift
+++ b/BuddyBuddy/Presentation/Home/View/DefaultChannelTableViewCell.swift
@@ -36,7 +36,10 @@ final class DefaultChannelTableViewCell: BaseTableViewCell {
         }
     }
     
-    func configureCell(title: String, image: String) {
+    func configureCell(
+        title: String,
+        image: String
+    ) {
         titleLabel.text = title
         iconImgView.image = UIImage(systemName: image)
         

--- a/BuddyBuddy/Presentation/Home/View/ReadChannelTableViewCell.swift
+++ b/BuddyBuddy/Presentation/Home/View/ReadChannelTableViewCell.swift
@@ -35,7 +35,7 @@ final class ReadChannelTableViewCell: BaseTableViewCell {
             make.leading.equalToSuperview().inset(16)
             make.size.equalTo(18)
         }
-        titleLabel.snp.remakeConstraints { make in
+        titleLabel.snp.makeConstraints { make in
             make.verticalEdges.equalToSuperview()
             make.leading.equalTo(iconImgView.snp.trailing).offset(12)
             make.height.equalTo(41)

--- a/BuddyBuddy/Presentation/Home/View/ReadChannelTableViewCell.swift
+++ b/BuddyBuddy/Presentation/Home/View/ReadChannelTableViewCell.swift
@@ -9,10 +9,11 @@ import UIKit
 
 import SnapKit
 
-final class DefaultChannelTableViewCell: BaseTableViewCell {
+final class ReadChannelTableViewCell: BaseTableViewCell {
     private let iconImgView: UIImageView = {
         let view = UIImageView()
         view.tintColor = .gray1
+        view.image = UIImage(systemName: "number")
         return view
     }()
     private let titleLabel: UILabel = {
@@ -34,27 +35,14 @@ final class DefaultChannelTableViewCell: BaseTableViewCell {
             make.leading.equalToSuperview().inset(16)
             make.size.equalTo(18)
         }
+        titleLabel.snp.remakeConstraints { make in
+            make.verticalEdges.equalToSuperview()
+            make.leading.equalTo(iconImgView.snp.trailing).offset(12)
+            make.height.equalTo(41)
+        }
     }
     
-    func configureCell(
-        title: String,
-        image: String
-    ) {
+    func configureCell(title: String) {
         titleLabel.text = title
-        iconImgView.image = UIImage(systemName: image)
-        
-        if image == "plus" {
-            titleLabel.snp.remakeConstraints { make in
-                make.verticalEdges.equalToSuperview()
-                make.leading.equalTo(iconImgView.snp.trailing).offset(12)
-                make.height.equalTo(48)
-            }
-        } else {
-            titleLabel.snp.remakeConstraints { make in
-                make.verticalEdges.equalToSuperview()
-                make.leading.equalTo(iconImgView.snp.trailing).offset(12)
-                make.height.equalTo(41)
-            }
-        }
     }
 }

--- a/BuddyBuddy/Presentation/Home/View/UnreadChannelTableViewCell.swift
+++ b/BuddyBuddy/Presentation/Home/View/UnreadChannelTableViewCell.swift
@@ -39,13 +39,11 @@ final class UnreadChannelTableViewCell: BaseTableViewCell {
             make.leading.equalToSuperview().inset(16)
             make.size.equalTo(18)
         }
-        
         titleLabel.snp.makeConstraints { make in
             make.verticalEdges.equalToSuperview()
             make.leading.equalTo(iconImgView.snp.trailing).offset(12)
             make.height.equalTo(41)
         }
-        
         notificationView.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.trailing.equalToSuperview().inset(24)

--- a/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
@@ -140,7 +140,7 @@ final class HomeViewController: BaseNavigationViewController {
                                                 title: "오픽 딸 사람덜~ 여기 모여요",
                                                 isRead: true)
                                                )]),
-                                               .add(item: .add("Add Channel".localized()))]
+                                               .add(items: [.add("Add Channel".localized())])]
         
         Observable.just(sections)
             .bind(to: channelTableView.rx.items(dataSource: datasource))

--- a/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
@@ -34,7 +34,12 @@ final class HomeViewController: BaseNavigationViewController {
         var config = UIButton.Configuration.plain()
         
         config.image = .menu
-        config.contentInsets = .init(top: 0, leading: 0, bottom: 0, trailing: 0)
+        config.contentInsets = .init(
+            top: 0,
+            leading: 0,
+            bottom: 0,
+            trailing: 0
+        )
         
         view.configuration = config
         return view
@@ -72,7 +77,12 @@ final class HomeViewController: BaseNavigationViewController {
         config.imagePlacement = .leading
         config.imagePadding = 12
         config.baseForegroundColor = .gray1
-        config.contentInsets = .init(top: 0, leading: 16, bottom: 0, trailing: 0)
+        config.contentInsets = .init(
+            top: 0,
+            leading: 16,
+            bottom: 0,
+            trailing: 0
+        )
         
         view.configuration = config
         view.backgroundColor = .white
@@ -82,7 +92,6 @@ final class HomeViewController: BaseNavigationViewController {
     private let emptyView: UIView = {
         let view = UIView()
         view.backgroundColor = .white
-        view.setContentHuggingPriority(.init(1), for: .vertical)
         return view
     }()
     private let floatingBtn: UIButton = {
@@ -90,7 +99,12 @@ final class HomeViewController: BaseNavigationViewController {
         var config = UIButton.Configuration.plain()
         
         config.image = .newMessage
-        config.contentInsets = .init(top: 16.45, leading: 16.45, bottom: 16.45, trailing: 16.45)
+        config.contentInsets = .init(
+            top: 16.45,
+            leading: 16.45,
+            bottom: 16.45,
+            trailing: 16.45
+        )
         
         view.configuration = config
         view.layer.cornerRadius = 25
@@ -171,21 +185,17 @@ final class HomeViewController: BaseNavigationViewController {
         scrollView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
-        
         stackView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
             make.width.equalToSuperview()
         }
-        
         memberAddBtn.snp.makeConstraints { make in
             make.height.equalTo(48)
         }
-        
         emptyView.snp.makeConstraints { make in
             make.bottom.equalToSuperview()
             make.height.equalTo(300)
         }
-        
         floatingBtn.snp.makeConstraints { make in
             make.trailing.bottom.equalTo(view.safeAreaLayoutGuide).inset(16)
             make.size.equalTo(50)
@@ -196,7 +206,11 @@ final class HomeViewController: BaseNavigationViewController {
 // MARK: RxDataSource
 extension HomeViewController {
     private func createDataSource() -> RxTableViewSectionedReloadDataSource<ChannelSectionModel> {
-        return RxTableViewSectionedReloadDataSource<ChannelSectionModel> { [weak self] datasource, _, indexpath, _ in
+        return RxTableViewSectionedReloadDataSource<ChannelSectionModel> {
+            [weak self] datasource,
+            _,
+            indexpath,
+            _ in
             guard let self else { return UITableViewCell() }
             
             switch datasource[indexpath] {
@@ -214,7 +228,10 @@ extension HomeViewController {
                         withIdentifier: DefaultChannelTableViewCell.identifier,
                         for: indexpath
                     ) as? DefaultChannelTableViewCell else { return UITableViewCell() }
-                    cell.configureCell(title: item.title, image: item.image)
+                    cell.configureCell(
+                        title: item.title,
+                        image: item.image
+                    )
                     cell.selectionStyle = .none
                     return cell
                 } else {
@@ -231,7 +248,10 @@ extension HomeViewController {
                     withIdentifier: DefaultChannelTableViewCell.identifier,
                     for: indexpath
                 ) as? DefaultChannelTableViewCell else { return UITableViewCell() }
-                cell.configureCell(title: item.title, image: item.imageString)
+                cell.configureCell(
+                    title: item.title,
+                    image: item.imageString
+                )
                 cell.selectionStyle = .none
                 return cell
             }

--- a/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
@@ -58,6 +58,10 @@ final class HomeViewController: BaseNavigationViewController {
             UnreadChannelTableViewCell.self,
             forCellReuseIdentifier: UnreadChannelTableViewCell.identifier
         )
+        view.register(
+            ChannelAddTableViewCell.self,
+            forCellReuseIdentifier: ChannelAddTableViewCell.identifier
+        )
         
         view.separatorStyle = .none
         view.isScrollEnabled = false
@@ -206,11 +210,7 @@ final class HomeViewController: BaseNavigationViewController {
 // MARK: RxDataSource
 extension HomeViewController {
     private func createDataSource() -> RxTableViewSectionedReloadDataSource<ChannelSectionModel> {
-        return RxTableViewSectionedReloadDataSource<ChannelSectionModel> {
-            [weak self] datasource,
-            _,
-            indexpath,
-            _ in
+        return RxTableViewSectionedReloadDataSource<ChannelSectionModel> { [weak self] datasource, _, indexpath, _ in
             guard let self else { return UITableViewCell() }
             
             switch datasource[indexpath] {
@@ -242,9 +242,9 @@ extension HomeViewController {
                 }
             case .add(let item):
                 guard let cell = channelTableView.dequeueReusableCell(
-                    withIdentifier: ReadChannelTableViewCell.identifier,
+                    withIdentifier: ChannelAddTableViewCell.identifier,
                     for: indexpath
-                ) as? ReadChannelTableViewCell else { return UITableViewCell() }
+                ) as? ChannelAddTableViewCell else { return UITableViewCell() }
                 cell.configureCell(title: item.title)
                 cell.selectionStyle = .none
                 return cell

--- a/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
@@ -129,7 +129,7 @@ final class HomeViewController: BaseNavigationViewController {
     
     override func bind() {
         let datasource = createDataSource()
-        let sections: [ChannelSectionModel] = [.title(items: [.title(.caret)]),
+        let sections: [ChannelSectionModel] = [.title(item: .title(.caret)),
                                                .list(items: [.channel(Channel(
                                                 title: "받아쓰기 할 사람들 모여라",
                                                 isRead: true
@@ -140,14 +140,17 @@ final class HomeViewController: BaseNavigationViewController {
                                                 title: "오픽 딸 사람덜~ 여기 모여요",
                                                 isRead: true)
                                                )]),
-                                               .add(items: [.add(AddChannel())])]
+                                               .add(item: .add("Add Channel".localized()))]
         
         Observable.just(sections)
             .bind(to: channelTableView.rx.items(dataSource: datasource))
             .disposed(by: disposeBag)
         
         channelTableView.snp.remakeConstraints { make in
-            make.height.equalTo(56 + sections[1].items.count * 41 + 48)
+            let headerHeight = 56
+            let listHeight = sections[1].items.count * 41
+            let addHeight = sections[2].items.count * 48
+            make.height.equalTo(headerHeight + listHeight + addHeight)
         }
     }
     
@@ -245,8 +248,8 @@ extension HomeViewController {
                     withIdentifier: ChannelAddTableViewCell.identifier,
                     for: indexpath
                 ) as? ChannelAddTableViewCell else { return UITableViewCell() }
-                cell.configureCell(title: item.title)
                 cell.selectionStyle = .none
+                cell.configureCell(title: item)
                 return cell
             }
         }

--- a/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
@@ -128,30 +128,7 @@ final class HomeViewController: BaseNavigationViewController {
     }
     
     override func bind() {
-        let datasource = createDataSource()
-        let sections: [ChannelSectionModel] = [.title(item: .title(.caret)),
-                                               .list(items: [.channel(Channel(
-                                                title: "받아쓰기 할 사람들 모여라",
-                                                isRead: true
-                                               )), .channel(Channel(
-                                                title: "스크립트 외우기",
-                                                isRead: false
-                                               )), .channel(Channel(
-                                                title: "오픽 딸 사람덜~ 여기 모여요",
-                                                isRead: true)
-                                               )]),
-                                               .add(items: [.add("Add Channel".localized())])]
-        
-        Observable.just(sections)
-            .bind(to: channelTableView.rx.items(dataSource: datasource))
-            .disposed(by: disposeBag)
-        
-        channelTableView.snp.remakeConstraints { make in
-            let headerHeight = 56
-            let listHeight = sections[1].items.count * 41
-            let addHeight = sections[2].items.count * 48
-            make.height.equalTo(headerHeight + listHeight + addHeight)
-        }
+        bindTableView()
     }
     
     override func setNavigation() {
@@ -252,6 +229,35 @@ extension HomeViewController {
                 cell.configureCell(title: item)
                 return cell
             }
+        }
+    }
+    
+    private func bindTableView() {
+        let datasource = createDataSource()
+        let sections: [ChannelSectionModel] = [.title(item: .title(.caret)),
+                                               .list(items: [.channel(Channel(
+                                                title: "받아쓰기 할 사람들 모여라",
+                                                isRead: true
+                                               )), .channel(Channel(
+                                                title: "스크립트 외우기",
+                                                isRead: false
+                                               )), .channel(Channel(
+                                                title: "오픽 딸 사람덜~ 여기 모여요",
+                                                isRead: true)
+                                               )]),
+                                               .add(items: [.add("Add Channel".localized())])]
+        
+        Observable.just(sections)
+            .bind(to: channelTableView.rx.items(dataSource: datasource))
+            .disposed(by: disposeBag)
+        
+        channelTableView.snp.remakeConstraints { make in
+            let heights = [56, 41, 48]
+            var totalHeight = 0
+            for (idx, section) in sections.enumerated() {
+                totalHeight += section.items.count * heights[idx]
+            }
+            make.height.equalTo(totalHeight)
         }
     }
 }

--- a/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
@@ -51,8 +51,8 @@ final class HomeViewController: BaseNavigationViewController {
             forCellReuseIdentifier: ChannelTitleTableViewCell.identifier
         )
         view.register(
-            DefaultChannelTableViewCell.self,
-            forCellReuseIdentifier: DefaultChannelTableViewCell.identifier
+            ReadChannelTableViewCell.self,
+            forCellReuseIdentifier: ReadChannelTableViewCell.identifier
         )
         view.register(
             UnreadChannelTableViewCell.self,
@@ -225,13 +225,10 @@ extension HomeViewController {
             case .channel(let item):
                 if item.isRead {
                     guard let cell = channelTableView.dequeueReusableCell(
-                        withIdentifier: DefaultChannelTableViewCell.identifier,
+                        withIdentifier: ReadChannelTableViewCell.identifier,
                         for: indexpath
-                    ) as? DefaultChannelTableViewCell else { return UITableViewCell() }
-                    cell.configureCell(
-                        title: item.title,
-                        image: item.image
-                    )
+                    ) as? ReadChannelTableViewCell else { return UITableViewCell() }
+                    cell.configureCell(title: item.title)
                     cell.selectionStyle = .none
                     return cell
                 } else {
@@ -245,13 +242,10 @@ extension HomeViewController {
                 }
             case .add(let item):
                 guard let cell = channelTableView.dequeueReusableCell(
-                    withIdentifier: DefaultChannelTableViewCell.identifier,
+                    withIdentifier: ReadChannelTableViewCell.identifier,
                     for: indexpath
-                ) as? DefaultChannelTableViewCell else { return UITableViewCell() }
-                cell.configureCell(
-                    title: item.title,
-                    image: item.imageString
-                )
+                ) as? ReadChannelTableViewCell else { return UITableViewCell() }
+                cell.configureCell(title: item.title)
                 cell.selectionStyle = .none
                 return cell
             }

--- a/BuddyBuddy/Utils/Extension/UIView+.swift
+++ b/BuddyBuddy/Utils/Extension/UIView+.swift
@@ -10,7 +10,10 @@ import UIKit
 extension UIView {
     func drawShadow(radius: CGFloat, size: CGSize) {
         let origin = self.bounds.origin
-        let point = CGPoint(x: origin.x, y: origin.y + 7.8)
+        let point = CGPoint(
+            x: origin.x,
+            y: origin.y + 7.8
+        )
         let rect = CGRect(
             origin: point,
             size: size


### PR DESCRIPTION
## 🚀관련 이슈
- close #13 

## ✨작업 내용
- 컨벤션 적용이 되지 않은 코드 수정
- cell이 load될 때마다 constraints가 매번 설정되는 문제 해결을 위해 cell 분리
- 채널 tableView의 title 섹션이 항상 1개이기 때문에 연관값을 배열이 아닌 데이터 하나만 받도록 수정
- 채널 tableView의 높이 계산 로직 수정
- 채널 tableView rxDataSource 바인딩 메서드로 분리

## 📝참고 사항
- rxDataSource 바인딩 메서드는 추후 비지니스 로직 구현 후 수정 될 가능성이 있습니다!
