### PR TITLE
[Feat] 채널 생성 UI 구현하기

### DIFF
--- a/BuddyBuddy.xcodeproj/project.pbxproj
+++ b/BuddyBuddy.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		C0327C7C2CE5870A00AEAEE1 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0327C7B2CE5870A00AEAEE1 /* UIView+.swift */; };
 		C079AEF42CEC827F00B34692 /* ChannelUseCaseInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C079AEF32CEC827F00B34692 /* ChannelUseCaseInterface.swift */; };
 		C079AEF62CEC835C00B34692 /* DefaultChannelUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C079AEF52CEC835C00B34692 /* DefaultChannelUseCase.swift */; };
+		C08644D12CF62C5E00862523 /* AddChannelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08644D02CF62C5E00862523 /* AddChannelViewModel.swift */; };
+		C08644D32CF6358000862523 /* ButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08644D22CF6358000862523 /* ButtonState.swift */; };
 		C09FA8E22CEC620700613FEA /* BuddyDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09FA8E12CEC620700613FEA /* BuddyDateFormatter.swift */; };
 		C09FA8E42CEC62A200613FEA /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09FA8E32CEC62A200613FEA /* Date+.swift */; };
 		C09FA8E62CEC635D00613FEA /* ChannelRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09FA8E52CEC635D00613FEA /* ChannelRouter.swift */; };
@@ -178,6 +180,8 @@
 		C0327C7B2CE5870A00AEAEE1 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		C079AEF32CEC827F00B34692 /* ChannelUseCaseInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelUseCaseInterface.swift; sourceTree = "<group>"; };
 		C079AEF52CEC835C00B34692 /* DefaultChannelUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChannelUseCase.swift; sourceTree = "<group>"; };
+		C08644D02CF62C5E00862523 /* AddChannelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChannelViewModel.swift; sourceTree = "<group>"; };
+		C08644D22CF6358000862523 /* ButtonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonState.swift; sourceTree = "<group>"; };
 		C09FA8E12CEC620700613FEA /* BuddyDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyDateFormatter.swift; sourceTree = "<group>"; };
 		C09FA8E32CEC62A200613FEA /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		C09FA8E52CEC635D00613FEA /* ChannelRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelRouter.swift; sourceTree = "<group>"; };
@@ -688,6 +692,7 @@
 				C91BBC242CE4D25C001EFC70 /* ChangeAdminViewModel.swift */,
 				C91BBC2C2CE4F830001EFC70 /* InviteMemberViewModel.swift */,
 				C98363DD2CE58AD400AC51CA /* ProfileViewModel.swift */,
+				C08644D02CF62C5E00862523 /* AddChannelViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1018,6 +1023,7 @@
 				C91BBC122CE3B62D001EFC70 /* RoundedButtonType.swift */,
 				C91F67402CEF2F8700C84265 /* SearchState.swift */,
 				C09FA8E12CEC620700613FEA /* BuddyDateFormatter.swift */,
+				C08644D22CF6358000862523 /* ButtonState.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -1277,6 +1283,7 @@
 				C09FA8FD2CEC6DFD00613FEA /* UnreadCountOfChannelResponseDTO.swift in Sources */,
 				DC213AA62CE374A700E2A2F7 /* DefaultDMUseCase.swift in Sources */,
 				DC213A8E2CE32C3E00E2A2F7 /* NetworkService.swift in Sources */,
+				C08644D32CF6358000862523 /* ButtonState.swift in Sources */,
 				C9F20F522CDB64890043351E /* SettingViewModel.swift in Sources */,
 				C9F20F5A2CDB66270043351E /* AppCoordinator.swift in Sources */,
 				C91BBC292CE4F370001EFC70 /* TitledTextField.swift in Sources */,
@@ -1410,6 +1417,7 @@
 				C91BBC1D2CE49366001EFC70 /* ChannelSettingViewController.swift in Sources */,
 				C079AEF42CEC827F00B34692 /* ChannelUseCaseInterface.swift in Sources */,
 				DC213AAF2CE4848B00E2A2F7 /* AccessTokenDTO.swift in Sources */,
+				C08644D12CF62C5E00862523 /* AddChannelViewModel.swift in Sources */,
 				DC9375682CECAB5D00012F43 /* DMRepositoryInterface.swift in Sources */,
 				DC213AB52CE4876700E2A2F7 /* LogInDTO.swift in Sources */,
 				DC213AA82CE4632F00E2A2F7 /* AuthIntercepter.swift in Sources */,

--- a/BuddyBuddy.xcodeproj/project.pbxproj
+++ b/BuddyBuddy.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		C0A35E052CF8516900B41E60 /* AddChannelReqeustDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E042CF8516900B41E60 /* AddChannelReqeustDTO.swift */; };
 		C0A35E072CF8606300B41E60 /* AddChannelResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E062CF8606300B41E60 /* AddChannelResponseDTO.swift */; };
 		C0A35E092CF860F400B41E60 /* AddChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E082CF860F400B41E60 /* AddChannel.swift */; };
+		C0A35E0B2CF8A3C600B41E60 /* ModalDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E0A2CF8A3C600B41E60 /* ModalDelegate.swift */; };
 		C0BF428B2CE4721600C5B5B4 /* Differentiator in Frameworks */ = {isa = PBXBuildFile; productRef = C0BF428A2CE4721600C5B5B4 /* Differentiator */; };
 		C0BF428D2CE4721600C5B5B4 /* RxDataSources in Frameworks */ = {isa = PBXBuildFile; productRef = C0BF428C2CE4721600C5B5B4 /* RxDataSources */; };
 		C0BF428F2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BF428E2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift */; };
@@ -201,6 +202,7 @@
 		C0A35E042CF8516900B41E60 /* AddChannelReqeustDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChannelReqeustDTO.swift; sourceTree = "<group>"; };
 		C0A35E062CF8606300B41E60 /* AddChannelResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChannelResponseDTO.swift; sourceTree = "<group>"; };
 		C0A35E082CF860F400B41E60 /* AddChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChannel.swift; sourceTree = "<group>"; };
+		C0A35E0A2CF8A3C600B41E60 /* ModalDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalDelegate.swift; sourceTree = "<group>"; };
 		C0BF428E2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTitleTableViewCell.swift; sourceTree = "<group>"; };
 		C0BF42922CE47A6100C5B5B4 /* ChannelTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTableViewCell.swift; sourceTree = "<group>"; };
 		C0BF42942CE4D71E00C5B5B4 /* ChannelSectionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelSectionModel.swift; sourceTree = "<group>"; };
@@ -922,6 +924,7 @@
 				DC9BC0DA2CE8DE9E002AF523 /* NetworkProtocol.swift */,
 				DC9375702CEDC0B900012F43 /* SocketProtocol.swift */,
 				DC9BC0E42CEA0CAB002AF523 /* KeyChainProtocol.swift */,
+				C0A35E0A2CF8A3C600B41E60 /* ModalDelegate.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1385,6 +1388,7 @@
 				C09FA8F52CEC673400613FEA /* MyChannelList.swift in Sources */,
 				C91BBC0B2CE3B162001EFC70 /* AlertType.swift in Sources */,
 				DC9375842CF4B78A00012F43 /* UserDefaultsManager.swift in Sources */,
+				C0A35E0B2CF8A3C600B41E60 /* ModalDelegate.swift in Sources */,
 				C09FA8E42CEC62A200613FEA /* Date+.swift in Sources */,
 				C9F20F562CDB64D30043351E /* AuthViewController.swift in Sources */,
 				C91BBC2B2CE4F7F0001EFC70 /* InviteMemberViewController.swift in Sources */,

--- a/BuddyBuddy.xcodeproj/project.pbxproj
+++ b/BuddyBuddy.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		C0A35E072CF8606300B41E60 /* AddChannelResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E062CF8606300B41E60 /* AddChannelResponseDTO.swift */; };
 		C0A35E092CF860F400B41E60 /* AddChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E082CF860F400B41E60 /* AddChannel.swift */; };
 		C0A35E0B2CF8A3C600B41E60 /* ModalDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E0A2CF8A3C600B41E60 /* ModalDelegate.swift */; };
+		C0A35E0D2CF8AAEC00B41E60 /* ToastMessageLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E0C2CF8AAEC00B41E60 /* ToastMessageLabel.swift */; };
 		C0BF428B2CE4721600C5B5B4 /* Differentiator in Frameworks */ = {isa = PBXBuildFile; productRef = C0BF428A2CE4721600C5B5B4 /* Differentiator */; };
 		C0BF428D2CE4721600C5B5B4 /* RxDataSources in Frameworks */ = {isa = PBXBuildFile; productRef = C0BF428C2CE4721600C5B5B4 /* RxDataSources */; };
 		C0BF428F2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BF428E2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift */; };
@@ -203,6 +204,7 @@
 		C0A35E062CF8606300B41E60 /* AddChannelResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChannelResponseDTO.swift; sourceTree = "<group>"; };
 		C0A35E082CF860F400B41E60 /* AddChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChannel.swift; sourceTree = "<group>"; };
 		C0A35E0A2CF8A3C600B41E60 /* ModalDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalDelegate.swift; sourceTree = "<group>"; };
+		C0A35E0C2CF8AAEC00B41E60 /* ToastMessageLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastMessageLabel.swift; sourceTree = "<group>"; };
 		C0BF428E2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTitleTableViewCell.swift; sourceTree = "<group>"; };
 		C0BF42922CE47A6100C5B5B4 /* ChannelTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTableViewCell.swift; sourceTree = "<group>"; };
 		C0BF42942CE4D71E00C5B5B4 /* ChannelSectionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelSectionModel.swift; sourceTree = "<group>"; };
@@ -986,6 +988,7 @@
 				C98363E32CE5A3E800AC51CA /* SystemImageLabelView.swift */,
 				DC213A832CE23E1B00E2A2F7 /* MessageCountView.swift */,
 				DC213A892CE3190700E2A2F7 /* SpeechBubbleView.swift */,
+				C0A35E0C2CF8AAEC00B41E60 /* ToastMessageLabel.swift */,
 			);
 			path = Custom;
 			sourceTree = "<group>";
@@ -1398,6 +1401,7 @@
 				DC213A8A2CE3190700E2A2F7 /* SpeechBubbleView.swift in Sources */,
 				C9E44A982CECB4DC0044CD5C /* SearchDTO.swift in Sources */,
 				DC9BC0DF2CE9BB4B002AF523 /* DMUnRead.swift in Sources */,
+				C0A35E0D2CF8AAEC00B41E60 /* ToastMessageLabel.swift in Sources */,
 				DC9375642CEC7E6500012F43 /* UserInfo.swift in Sources */,
 				C9F20F6E2CDB743D0043351E /* AuthCoordinator.swift in Sources */,
 				DC9BC0E52CEA0CAB002AF523 /* KeyChainProtocol.swift in Sources */,

--- a/BuddyBuddy.xcodeproj/project.pbxproj
+++ b/BuddyBuddy.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		C09FA9002CEC6FAF00613FEA /* ChannelRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09FA8FF2CEC6FAF00613FEA /* ChannelRepositoryInterface.swift */; };
 		C09FA9032CEC716500613FEA /* DefaultChannelRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09FA9022CEC716500613FEA /* DefaultChannelRepository.swift */; };
 		C0A35E022CF786CA00B41E60 /* RegularExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E012CF786CA00B41E60 /* RegularExpression.swift */; };
+		C0A35E052CF8516900B41E60 /* AddChannelReqeustDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E042CF8516900B41E60 /* AddChannelReqeustDTO.swift */; };
+		C0A35E072CF8606300B41E60 /* AddChannelResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E062CF8606300B41E60 /* AddChannelResponseDTO.swift */; };
+		C0A35E092CF860F400B41E60 /* AddChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E082CF860F400B41E60 /* AddChannel.swift */; };
 		C0BF428B2CE4721600C5B5B4 /* Differentiator in Frameworks */ = {isa = PBXBuildFile; productRef = C0BF428A2CE4721600C5B5B4 /* Differentiator */; };
 		C0BF428D2CE4721600C5B5B4 /* RxDataSources in Frameworks */ = {isa = PBXBuildFile; productRef = C0BF428C2CE4721600C5B5B4 /* RxDataSources */; };
 		C0BF428F2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BF428E2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift */; };
@@ -195,6 +198,9 @@
 		C09FA8FF2CEC6FAF00613FEA /* ChannelRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelRepositoryInterface.swift; sourceTree = "<group>"; };
 		C09FA9022CEC716500613FEA /* DefaultChannelRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChannelRepository.swift; sourceTree = "<group>"; };
 		C0A35E012CF786CA00B41E60 /* RegularExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegularExpression.swift; sourceTree = "<group>"; };
+		C0A35E042CF8516900B41E60 /* AddChannelReqeustDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChannelReqeustDTO.swift; sourceTree = "<group>"; };
+		C0A35E062CF8606300B41E60 /* AddChannelResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChannelResponseDTO.swift; sourceTree = "<group>"; };
+		C0A35E082CF860F400B41E60 /* AddChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChannel.swift; sourceTree = "<group>"; };
 		C0BF428E2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTitleTableViewCell.swift; sourceTree = "<group>"; };
 		C0BF42922CE47A6100C5B5B4 /* ChannelTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTableViewCell.swift; sourceTree = "<group>"; };
 		C0BF42942CE4D71E00C5B5B4 /* ChannelSectionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelSectionModel.swift; sourceTree = "<group>"; };
@@ -373,6 +379,7 @@
 			isa = PBXGroup;
 			children = (
 				C09FA8EE2CEC664300613FEA /* Response */,
+				C0A35E032CF8515300B41E60 /* Request */,
 			);
 			path = Channel;
 			sourceTree = "<group>";
@@ -382,6 +389,7 @@
 			children = (
 				C09FA8EF2CEC668800613FEA /* MyChannelListResponseDTO.swift */,
 				C09FA8FC2CEC6DFD00613FEA /* UnreadCountOfChannelResponseDTO.swift */,
+				C0A35E062CF8606300B41E60 /* AddChannelResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -392,6 +400,7 @@
 				C0BF42942CE4D71E00C5B5B4 /* ChannelSectionModel.swift */,
 				C09FA8F42CEC673400613FEA /* MyChannelList.swift */,
 				C09FA8FA2CEC6DD200613FEA /* UnreadCountOfChannel.swift */,
+				C0A35E082CF860F400B41E60 /* AddChannel.swift */,
 			);
 			path = Channel;
 			sourceTree = "<group>";
@@ -402,6 +411,14 @@
 				C09FA8FF2CEC6FAF00613FEA /* ChannelRepositoryInterface.swift */,
 			);
 			path = Channel;
+			sourceTree = "<group>";
+		};
+		C0A35E032CF8515300B41E60 /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				C0A35E042CF8516900B41E60 /* AddChannelReqeustDTO.swift */,
+			);
+			path = Request;
 			sourceTree = "<group>";
 		};
 		C0CF50C12CF4824400F131A0 /* Profile */ = {
@@ -1282,6 +1299,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C0A35E052CF8516900B41E60 /* AddChannelReqeustDTO.swift in Sources */,
 				DC213AB82CE6186800E2A2F7 /* DMListViewController.swift in Sources */,
 				DC213AB92CE6186800E2A2F7 /* DMListViewModel.swift in Sources */,
 				C91BBC192CE487BA001EFC70 /* ChannelSettingBottomView.swift in Sources */,
@@ -1311,6 +1329,7 @@
 				C9F20F4E2CDB64330043351E /* SearchViewModel.swift in Sources */,
 				C9F20F662CDB72A60043351E /* SearchCoordinator.swift in Sources */,
 				C96C72952CDAF9CA00E0D6CF /* BaseView.swift in Sources */,
+				C0A35E072CF8606300B41E60 /* AddChannelResponseDTO.swift in Sources */,
 				C9F20F642CDB709A0043351E /* DefaultDMCoordinator.swift in Sources */,
 				C98363DE2CE58AD400AC51CA /* ProfileViewModel.swift in Sources */,
 				DC9375712CEDC0B900012F43 /* SocketProtocol.swift in Sources */,
@@ -1430,6 +1449,7 @@
 				DC213AB52CE4876700E2A2F7 /* LogInDTO.swift in Sources */,
 				DC213AA82CE4632F00E2A2F7 /* AuthIntercepter.swift in Sources */,
 				DC213A902CE32C4500E2A2F7 /* LogInRouter.swift in Sources */,
+				C0A35E092CF860F400B41E60 /* AddChannel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BuddyBuddy.xcodeproj/project.pbxproj
+++ b/BuddyBuddy.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		C09FA8FD2CEC6DFD00613FEA /* UnreadCountOfChannelResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09FA8FC2CEC6DFD00613FEA /* UnreadCountOfChannelResponseDTO.swift */; };
 		C09FA9002CEC6FAF00613FEA /* ChannelRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09FA8FF2CEC6FAF00613FEA /* ChannelRepositoryInterface.swift */; };
 		C09FA9032CEC716500613FEA /* DefaultChannelRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09FA9022CEC716500613FEA /* DefaultChannelRepository.swift */; };
+		C0A35E022CF786CA00B41E60 /* RegularExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E012CF786CA00B41E60 /* RegularExpression.swift */; };
 		C0BF428B2CE4721600C5B5B4 /* Differentiator in Frameworks */ = {isa = PBXBuildFile; productRef = C0BF428A2CE4721600C5B5B4 /* Differentiator */; };
 		C0BF428D2CE4721600C5B5B4 /* RxDataSources in Frameworks */ = {isa = PBXBuildFile; productRef = C0BF428C2CE4721600C5B5B4 /* RxDataSources */; };
 		C0BF428F2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BF428E2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift */; };
@@ -193,6 +194,7 @@
 		C09FA8FC2CEC6DFD00613FEA /* UnreadCountOfChannelResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadCountOfChannelResponseDTO.swift; sourceTree = "<group>"; };
 		C09FA8FF2CEC6FAF00613FEA /* ChannelRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelRepositoryInterface.swift; sourceTree = "<group>"; };
 		C09FA9022CEC716500613FEA /* DefaultChannelRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChannelRepository.swift; sourceTree = "<group>"; };
+		C0A35E012CF786CA00B41E60 /* RegularExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegularExpression.swift; sourceTree = "<group>"; };
 		C0BF428E2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTitleTableViewCell.swift; sourceTree = "<group>"; };
 		C0BF42922CE47A6100C5B5B4 /* ChannelTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTableViewCell.swift; sourceTree = "<group>"; };
 		C0BF42942CE4D71E00C5B5B4 /* ChannelSectionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelSectionModel.swift; sourceTree = "<group>"; };
@@ -1027,6 +1029,7 @@
 				C91F67402CEF2F8700C84265 /* SearchState.swift */,
 				C09FA8E12CEC620700613FEA /* BuddyDateFormatter.swift */,
 				C08644D22CF6358000862523 /* ButtonState.swift */,
+				C0A35E012CF786CA00B41E60 /* RegularExpression.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -1410,6 +1413,7 @@
 				C91F67342CEE444500C84265 /* MyProfile.swift in Sources */,
 				C0BF428F2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift in Sources */,
 				C9E44A9A2CECBC410044CD5C /* PlaygroundRouter.swift in Sources */,
+				C0A35E022CF786CA00B41E60 /* RegularExpression.swift in Sources */,
 				DC213A842CE23E1B00E2A2F7 /* MessageCountView.swift in Sources */,
 				DC213AAC2CE47A8900E2A2F7 /* LoginQuery.swift in Sources */,
 				DC9BC0DD2CE9BB21002AF523 /* DMUnReadDTO.swift in Sources */,

--- a/BuddyBuddy.xcodeproj/project.pbxproj
+++ b/BuddyBuddy.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		C0A35E092CF860F400B41E60 /* AddChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E082CF860F400B41E60 /* AddChannel.swift */; };
 		C0A35E0B2CF8A3C600B41E60 /* ModalDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E0A2CF8A3C600B41E60 /* ModalDelegate.swift */; };
 		C0A35E0D2CF8AAEC00B41E60 /* ToastMessageLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E0C2CF8AAEC00B41E60 /* ToastMessageLabel.swift */; };
+		C0A35E0F2CF8CB0B00B41E60 /* ToastMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A35E0E2CF8CB0B00B41E60 /* ToastMessage.swift */; };
 		C0BF428B2CE4721600C5B5B4 /* Differentiator in Frameworks */ = {isa = PBXBuildFile; productRef = C0BF428A2CE4721600C5B5B4 /* Differentiator */; };
 		C0BF428D2CE4721600C5B5B4 /* RxDataSources in Frameworks */ = {isa = PBXBuildFile; productRef = C0BF428C2CE4721600C5B5B4 /* RxDataSources */; };
 		C0BF428F2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BF428E2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift */; };
@@ -205,6 +206,7 @@
 		C0A35E082CF860F400B41E60 /* AddChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChannel.swift; sourceTree = "<group>"; };
 		C0A35E0A2CF8A3C600B41E60 /* ModalDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalDelegate.swift; sourceTree = "<group>"; };
 		C0A35E0C2CF8AAEC00B41E60 /* ToastMessageLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastMessageLabel.swift; sourceTree = "<group>"; };
+		C0A35E0E2CF8CB0B00B41E60 /* ToastMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastMessage.swift; sourceTree = "<group>"; };
 		C0BF428E2CE473BF00C5B5B4 /* ChannelTitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTitleTableViewCell.swift; sourceTree = "<group>"; };
 		C0BF42922CE47A6100C5B5B4 /* ChannelTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTableViewCell.swift; sourceTree = "<group>"; };
 		C0BF42942CE4D71E00C5B5B4 /* ChannelSectionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelSectionModel.swift; sourceTree = "<group>"; };
@@ -1053,6 +1055,7 @@
 				C09FA8E12CEC620700613FEA /* BuddyDateFormatter.swift */,
 				C08644D22CF6358000862523 /* ButtonState.swift */,
 				C0A35E012CF786CA00B41E60 /* RegularExpression.swift */,
+				C0A35E0E2CF8CB0B00B41E60 /* ToastMessage.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -1308,6 +1311,7 @@
 				C0A35E052CF8516900B41E60 /* AddChannelReqeustDTO.swift in Sources */,
 				DC213AB82CE6186800E2A2F7 /* DMListViewController.swift in Sources */,
 				DC213AB92CE6186800E2A2F7 /* DMListViewModel.swift in Sources */,
+				C0A35E0F2CF8CB0B00B41E60 /* ToastMessage.swift in Sources */,
 				C91BBC192CE487BA001EFC70 /* ChannelSettingBottomView.swift in Sources */,
 				DC9375732CEDF8A000012F43 /* UserInfoDTO.swift in Sources */,
 				C09FA8FD2CEC6DFD00613FEA /* UnreadCountOfChannelResponseDTO.swift in Sources */,

--- a/BuddyBuddy.xcodeproj/project.pbxproj
+++ b/BuddyBuddy.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		C079AEF62CEC835C00B34692 /* DefaultChannelUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C079AEF52CEC835C00B34692 /* DefaultChannelUseCase.swift */; };
 		C08644D12CF62C5E00862523 /* AddChannelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08644D02CF62C5E00862523 /* AddChannelViewModel.swift */; };
 		C08644D32CF6358000862523 /* ButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08644D22CF6358000862523 /* ButtonState.swift */; };
+		C08644D52CF6E3C300862523 /* AddChannelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08644D42CF6E3C300862523 /* AddChannelViewController.swift */; };
 		C09FA8E22CEC620700613FEA /* BuddyDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09FA8E12CEC620700613FEA /* BuddyDateFormatter.swift */; };
 		C09FA8E42CEC62A200613FEA /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09FA8E32CEC62A200613FEA /* Date+.swift */; };
 		C09FA8E62CEC635D00613FEA /* ChannelRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09FA8E52CEC635D00613FEA /* ChannelRouter.swift */; };
@@ -182,6 +183,7 @@
 		C079AEF52CEC835C00B34692 /* DefaultChannelUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChannelUseCase.swift; sourceTree = "<group>"; };
 		C08644D02CF62C5E00862523 /* AddChannelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChannelViewModel.swift; sourceTree = "<group>"; };
 		C08644D22CF6358000862523 /* ButtonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonState.swift; sourceTree = "<group>"; };
+		C08644D42CF6E3C300862523 /* AddChannelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChannelViewController.swift; sourceTree = "<group>"; };
 		C09FA8E12CEC620700613FEA /* BuddyDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyDateFormatter.swift; sourceTree = "<group>"; };
 		C09FA8E32CEC62A200613FEA /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		C09FA8E52CEC635D00613FEA /* ChannelRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelRouter.swift; sourceTree = "<group>"; };
@@ -680,6 +682,7 @@
 				C91BBC222CE4CF97001EFC70 /* ChannelAdminViewController.swift */,
 				C91BBC2A2CE4F7F0001EFC70 /* InviteMemberViewController.swift */,
 				C98363DB2CE58AA200AC51CA /* ProfileViewController.swift */,
+				C08644D42CF6E3C300862523 /* AddChannelViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -1400,6 +1403,7 @@
 				C96C72992CDAF9EA00E0D6CF /* BaseNavigationViewController.swift in Sources */,
 				C91F67442CF098C900C84265 /* Data+.swift in Sources */,
 				C9F20F542CDB64C10043351E /* AuthViewModel.swift in Sources */,
+				C08644D52CF6E3C300862523 /* AddChannelViewController.swift in Sources */,
 				DC213A822CE1F6F200E2A2F7 /* DMListTableViewCell.swift in Sources */,
 				DC213A962CE3668700E2A2F7 /* APIKey.swift in Sources */,
 				C9F20F422CDB61F50043351E /* HomeViewController.swift in Sources */,

--- a/BuddyBuddy/App/AppDelegate+Register.swift
+++ b/BuddyBuddy/App/AppDelegate+Register.swift
@@ -45,5 +45,10 @@ extension AppDelegate {
             type: ChannelRepositoryInterface.self,
             DefaultChannelRepository(networkService: networkService)
         )
+        
+        DIContainer.register(
+            type: ChannelUseCaseInterface.self,
+            DefaultChannelUseCase()
+        )
     }
 }

--- a/BuddyBuddy/Data/DTO/Channel/Request/AddChannelReqeustDTO.swift
+++ b/BuddyBuddy/Data/DTO/Channel/Request/AddChannelReqeustDTO.swift
@@ -1,0 +1,13 @@
+//
+//  AddChannelReqeustDTO.swift
+//  BuddyBuddy
+//
+//  Created by 아라 on 11/28/24.
+//
+
+import Foundation
+
+struct AddChannelReqeustDTO: Encodable {
+    let name: String
+    let description: String?
+}

--- a/BuddyBuddy/Data/DTO/Channel/Response/AddChannelResponseDTO.swift
+++ b/BuddyBuddy/Data/DTO/Channel/Response/AddChannelResponseDTO.swift
@@ -1,0 +1,33 @@
+//
+//  AddChannelResponseDTO.swift
+//  BuddyBuddy
+//
+//  Created by 아라 on 11/28/24.
+//
+
+import Foundation
+
+struct AddChannelResponseDTO: Decodable {
+    let channelID, name: String
+    let description: String?
+    let ownerID, createdAt: String
+    
+    enum CodingKeys: String, CodingKey {
+        case channelID = "channel_id"
+        case name, description
+        case ownerID = "owner_id"
+        case createdAt
+    }
+}
+
+extension AddChannelResponseDTO {
+    func toDomain() -> AddChannel {
+        return AddChannel(
+            channelID: channelID,
+            name: name,
+            description: description,
+            ownerID: ownerID,
+            createdAt: createdAt
+        )
+    }
+}

--- a/BuddyBuddy/Data/Repository/DefaultChannelRepository.swift
+++ b/BuddyBuddy/Data/Repository/DefaultChannelRepository.swift
@@ -54,4 +54,19 @@ final class DefaultChannelRepository: ChannelRepositoryInterface {
             }
         }
     }
+    
+    func createChannel(request: AddChannelReqeustDTO) -> Single<Result<AddChannel, any Error>> {
+        networkService.callRequest(
+            router: Router.createChannel(request: request),
+            responseType: AddChannelResponseDTO.self
+        )
+        .map { result in
+            switch result {
+            case .success(let dto):
+                return .success(dto.toDomain())
+            case .failure(let error):
+                return .failure(error)
+            }
+        }
+    }
 }

--- a/BuddyBuddy/Domain/Entity/Channel/AddChannel.swift
+++ b/BuddyBuddy/Domain/Entity/Channel/AddChannel.swift
@@ -1,0 +1,14 @@
+//
+//  AddChannel.swift
+//  BuddyBuddy
+//
+//  Created by 아라 on 11/28/24.
+//
+
+import Foundation
+
+struct AddChannel {
+    let channelID, name: String
+    let description: String?
+    let ownerID, createdAt: String
+}

--- a/BuddyBuddy/Domain/RepositoryInterface/Channel/ChannelRepositoryInterface.swift
+++ b/BuddyBuddy/Domain/RepositoryInterface/Channel/ChannelRepositoryInterface.swift
@@ -16,4 +16,5 @@ protocol ChannelRepositoryInterface {
         channelID: String,
         after: Date?
     ) -> Single<Result<UnreadCountOfChannel, Error>>
+    func createChannel(request: AddChannelReqeustDTO) -> Single<Result<AddChannel, Error>>
 }

--- a/BuddyBuddy/Domain/UseCase/DefaultChannelUseCase.swift
+++ b/BuddyBuddy/Domain/UseCase/DefaultChannelUseCase.swift
@@ -28,4 +28,8 @@ final class DefaultChannelUseCase: ChannelUseCaseInterface {
             after: after
         )
     }
+    
+    func createChannel(request: AddChannelReqeustDTO) -> Single<Result<AddChannel, any Error>> {
+        repository.createChannel(request: request)
+    }
 }

--- a/BuddyBuddy/Domain/UseCaseInterface/ChannelUseCaseInterface.swift
+++ b/BuddyBuddy/Domain/UseCaseInterface/ChannelUseCaseInterface.swift
@@ -16,4 +16,5 @@ protocol ChannelUseCaseInterface {
         channelID: String,
         after: Date?
     ) -> Single<Result<UnreadCountOfChannel, Error>>
+    func createChannel(request: AddChannelReqeustDTO) -> Single<Result<AddChannel, Error>>
 }

--- a/BuddyBuddy/Presentation/Custom/ModalNavigationView.swift
+++ b/BuddyBuddy/Presentation/Custom/ModalNavigationView.swift
@@ -48,10 +48,10 @@ final class ModalNavigationView: BaseView {
         backBtn.snp.makeConstraints { make in
             make.size.equalTo(20)
             make.leading.equalToSuperview().inset(14)
-            make.centerY.equalToSuperview().offset(10)
+            make.centerY.equalToSuperview().offset(3)
         }
         titleLabel.snp.makeConstraints { make in
-            make.centerY.equalToSuperview().offset(10)
+            make.centerY.equalToSuperview().offset(3)
             make.centerX.equalToSuperview()
         }
         bottomBar.snp.makeConstraints { make in

--- a/BuddyBuddy/Presentation/Custom/RoundedButton.swift
+++ b/BuddyBuddy/Presentation/Custom/RoundedButton.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 final class RoundedButton: UIButton {
+    private var title: String?
     
     init(btnType: RoundedButtonType) {
         super.init(frame: .zero)
@@ -38,12 +39,35 @@ final class RoundedButton: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
     
+    func updateBtn(
+        bgColor: UIColor,
+        txtColor: UIColor
+    ) {
+        guard var config = configuration,
+              let title else { return }
+        
+        let attributes = AttributeContainer([
+            .font: UIFont.title2 as Any,
+            .foregroundColor: txtColor
+        ])
+        
+        config.baseBackgroundColor = bgColor
+        config.attributedTitle = AttributedString.init(
+            title,
+            attributes: attributes
+        )
+        
+        configuration = config
+    }
+    
     func setupBtn(
         title: String,
         bgColor: UIColor,
         txtColor: UIColor,
         btnType: RoundedButtonType
     ) {
+        self.title = title
+        
         var config = UIButton.Configuration.filled()
         
         config.baseBackgroundColor = bgColor

--- a/BuddyBuddy/Presentation/Custom/TitledTextField.swift
+++ b/BuddyBuddy/Presentation/Custom/TitledTextField.swift
@@ -52,7 +52,7 @@ final class TitledTextField: BaseView {
     override func setView() {
         super.setView()
         
-        backgroundColor = .gray2
+        backgroundColor = .gray3
     }
     
     override func setConstraints() {

--- a/BuddyBuddy/Presentation/Custom/ToastMessageLabel.swift
+++ b/BuddyBuddy/Presentation/Custom/ToastMessageLabel.swift
@@ -43,4 +43,16 @@ class ToastMessageLabel: UILabel {
         layer.cornerRadius = 12
         clipsToBounds = true
     }
+    
+    func animation() {
+        UIView.animate(withDuration: 1.5, delay: 0.5) { [weak self] in
+            guard let self else { return }
+            isHidden = false
+            alpha = 0
+        } completion: { [weak self] _ in
+            guard let self else { return }
+            alpha = 1
+            isHidden = true
+        }
+    }
 }

--- a/BuddyBuddy/Presentation/Custom/ToastMessageLabel.swift
+++ b/BuddyBuddy/Presentation/Custom/ToastMessageLabel.swift
@@ -1,0 +1,46 @@
+//
+//  ToastMessageLabel.swift
+//  BuddyBuddy
+//
+//  Created by 아라 on 11/28/24.
+//
+
+import UIKit
+
+class ToastMessageLabel: UILabel {
+    private var padding = UIEdgeInsets(top: 13.0, left: 16.0, bottom: 13.0, right: 16.0)
+
+    convenience init(padding: UIEdgeInsets) {
+        self.init(frame: .zero)
+        self.padding = padding
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: padding))
+    }
+
+    override var intrinsicContentSize: CGSize {
+        var contentSize = super.intrinsicContentSize
+        contentSize.height += padding.top + padding.bottom
+        contentSize.width += padding.left + padding.right
+
+        return contentSize
+    }
+    
+    private func setUI() {
+        backgroundColor = .primary
+        textColor = .secondary
+        font = UIFont.body
+        layer.cornerRadius = 12
+        clipsToBounds = true
+    }
+}

--- a/BuddyBuddy/Presentation/Home/Coordinator/DefaultHomeCoordinator.swift
+++ b/BuddyBuddy/Presentation/Home/Coordinator/DefaultHomeCoordinator.swift
@@ -8,13 +8,15 @@
 import UIKit
 
 final class DefaultHomeCoordinator: HomeCoordinator {
+    @Dependency(ChannelUseCaseInterface.self)
+    private var channelUseCase: ChannelUseCaseInterface
     var parent: Coordinator?
     var childs: [Coordinator] = []
     var navigationController: UINavigationController
     
     private lazy var homeVM = HomeViewModel(
         coordinator: self,
-        channelUseCase: DefaultChannelUseCase()
+        channelUseCase: channelUseCase
     )
     
     init(navigationController: UINavigationController) {
@@ -86,7 +88,7 @@ final class DefaultHomeCoordinator: HomeCoordinator {
     
     func toAddChannel() {
         let vm = AddChannelViewModel(
-            channelUseCase: DefaultChannelUseCase(),
+            channelUseCase: channelUseCase,
             coordinator: self)
         vm.delegate = homeVM
         

--- a/BuddyBuddy/Presentation/Home/Coordinator/DefaultHomeCoordinator.swift
+++ b/BuddyBuddy/Presentation/Home/Coordinator/DefaultHomeCoordinator.swift
@@ -12,15 +12,17 @@ final class DefaultHomeCoordinator: HomeCoordinator {
     var childs: [Coordinator] = []
     var navigationController: UINavigationController
     
+    private lazy var homeVM = HomeViewModel(
+        coordinator: self,
+        channelUseCase: DefaultChannelUseCase()
+    )
+    
     init(navigationController: UINavigationController) {
         self.navigationController = navigationController
     }
     
     func start() {
-        let vc = HomeViewController(vm: HomeViewModel(
-            coordinator: self,
-            channelUseCase: DefaultChannelUseCase())
-        )
+        let vc = HomeViewController(vm: homeVM)
         navigationController.pushViewController(
             vc,
             animated: true
@@ -83,7 +85,12 @@ final class DefaultHomeCoordinator: HomeCoordinator {
     }
     
     func toAddChannel() {
-        let vc = AddChannelViewController(vm: AddChannelViewModel(channelUseCase: DefaultChannelUseCase()))
+        let vm = AddChannelViewModel(
+            channelUseCase: DefaultChannelUseCase(),
+            coordinator: self)
+        vm.delegate = homeVM
+        
+        let vc = AddChannelViewController(vm: vm)
         vc.modalPresentationStyle = .pageSheet
         if let sheet = vc.sheetPresentationController {
             sheet.detents = [.large()]

--- a/BuddyBuddy/Presentation/Home/Coordinator/DefaultHomeCoordinator.swift
+++ b/BuddyBuddy/Presentation/Home/Coordinator/DefaultHomeCoordinator.swift
@@ -83,7 +83,7 @@ final class DefaultHomeCoordinator: HomeCoordinator {
     }
     
     func toAddChannel() {
-        let vc = AddChannelViewController(vm: AddChannelViewModel())
+        let vc = AddChannelViewController(vm: AddChannelViewModel(channelUseCase: DefaultChannelUseCase()))
         vc.modalPresentationStyle = .pageSheet
         if let sheet = vc.sheetPresentationController {
             sheet.detents = [.large()]

--- a/BuddyBuddy/Presentation/Home/Coordinator/DefaultHomeCoordinator.swift
+++ b/BuddyBuddy/Presentation/Home/Coordinator/DefaultHomeCoordinator.swift
@@ -83,7 +83,7 @@ final class DefaultHomeCoordinator: HomeCoordinator {
     }
     
     func toAddChannel() {
-        let vc = AddChannelViewController()
+        let vc = AddChannelViewController(vm: AddChannelViewModel())
         vc.modalPresentationStyle = .pageSheet
         if let sheet = vc.sheetPresentationController {
             sheet.detents = [.large()]

--- a/BuddyBuddy/Presentation/Home/Coordinator/DefaultHomeCoordinator.swift
+++ b/BuddyBuddy/Presentation/Home/Coordinator/DefaultHomeCoordinator.swift
@@ -83,7 +83,16 @@ final class DefaultHomeCoordinator: HomeCoordinator {
     }
     
     func toAddChannel() {
-        // TODO: 채널 생성 화면 전환
+        let vc = AddChannelViewController()
+        vc.modalPresentationStyle = .pageSheet
+        if let sheet = vc.sheetPresentationController {
+            sheet.detents = [.large()]
+            sheet.prefersGrabberVisible = true
+        }
+        navigationController.present(
+            vc,
+            animated: true
+        )
     }
     
     func toPlayground() {

--- a/BuddyBuddy/Presentation/Home/ViewController/AddChannelViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/AddChannelViewController.swift
@@ -1,0 +1,46 @@
+//
+//  AddChannelViewController.swift
+//  BuddyBuddy
+//
+//  Created by 아라 on 11/27/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class AddChannelViewController: BaseViewController {
+    private let navigationView: ModalNavigationView = ModalNavigationView(title: "채널 생성")
+    private let channelNameTextField: TitledTextField = TitledTextField(
+        title: "채널 이름",
+        placeholder: "채널 이름을 입력하세요 (필수)"
+    )
+    private let channelContentTextField: TitledTextField = TitledTextField(
+        title: "채널 이름",
+        placeholder: "채널 이름을 입력하세요 (필수)"
+    )
+    
+    override func setHierarchy() {
+        [navigationView, channelNameTextField, channelContentTextField].forEach {
+            view.addSubview($0)
+        }
+    }
+    
+    override func setConstraints() {
+        navigationView.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(10)
+            make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(44)
+        }
+        channelNameTextField.snp.makeConstraints { make in
+            make.top.equalTo(navigationView.snp.bottom).offset(24)
+            make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(76)
+        }
+        channelContentTextField.snp.makeConstraints { make in
+            make.top.equalTo(channelNameTextField.snp.bottom).offset(24)
+            make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(76)
+        }
+    }
+}

--- a/BuddyBuddy/Presentation/Home/ViewController/AddChannelViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/AddChannelViewController.swift
@@ -50,6 +50,18 @@ final class AddChannelViewController: BaseViewController {
         )
         let output = vm.transform(input: input)
         
+        output.nameText
+            .drive(with: self) { owner, text in
+                owner.channelNameTextField.textField.text = text
+            }
+            .disposed(by: disposeBag)
+        
+        output.contentText
+            .drive(with: self) { owner, text in
+                owner.channelContentTextField.textField.text = text
+            }
+            .disposed(by: disposeBag)
+        
         output.okBtnState
             .drive(with: self) { owner, type in
                 switch type {

--- a/BuddyBuddy/Presentation/Home/ViewController/AddChannelViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/AddChannelViewController.swift
@@ -7,9 +7,14 @@
 
 import UIKit
 
+import RxCocoa
+import RxSwift
 import SnapKit
 
 final class AddChannelViewController: BaseViewController {
+    private let disposeBag = DisposeBag()
+    private let vm: AddChannelViewModel
+    
     private let navigationView: ModalNavigationView
     = ModalNavigationView(title: "CreateChannel".localized())
     private let channelNameTextField: TitledTextField = TitledTextField(
@@ -31,6 +36,39 @@ final class AddChannelViewController: BaseViewController {
         view.isEnabled = false
         return view
     }()
+    
+    init(vm: AddChannelViewModel) {
+        self.vm = vm
+        super.init()
+    }
+    
+    override func bind() {
+        let input = AddChannelViewModel.Input(
+            nameInputText: channelNameTextField.textField.rx.text.orEmpty.asObservable(),
+            contentInputText: channelContentTextField.textField.rx.text.orEmpty.asObservable(),
+            okBtnTapped: okBtn.rx.tap.asObservable()
+        )
+        let output = vm.transform(input: input)
+        
+        output.okBtnState
+            .drive(with: self) { owner, type in
+                switch type {
+                case .disable:
+                    owner.okBtn.isEnabled = false
+                    owner.okBtn.updateBtn(
+                        bgColor: .gray2,
+                        txtColor: .gray1
+                    )
+                case .enable:
+                    owner.okBtn.isEnabled = true
+                    owner.okBtn.updateBtn(
+                        bgColor: .primary,
+                        txtColor: .secondary
+                    )
+                }
+            }
+            .disposed(by: disposeBag)
+    }
     
     override func setView() {
         super.setView()

--- a/BuddyBuddy/Presentation/Home/ViewController/AddChannelViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/AddChannelViewController.swift
@@ -100,7 +100,7 @@ final class AddChannelViewController: BaseViewController {
         }
         okBtn.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview().inset(24)
-            make.bottom.equalTo(safeArea).inset(12)
+            make.bottom.equalTo(keyboardLayout.snp.top).offset(-12)
             make.height.equalTo(44)
         }
     }

--- a/BuddyBuddy/Presentation/Home/ViewController/AddChannelViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/AddChannelViewController.swift
@@ -10,15 +10,22 @@ import UIKit
 import SnapKit
 
 final class AddChannelViewController: BaseViewController {
-    private let navigationView: ModalNavigationView = ModalNavigationView(title: "채널 생성")
+    private let navigationView: ModalNavigationView
+    = ModalNavigationView(title: "CreateChannel".localized())
     private let channelNameTextField: TitledTextField = TitledTextField(
-        title: "채널 이름",
-        placeholder: "채널 이름을 입력하세요 (필수)"
+        title: "ChannelName".localized(),
+        placeholder: "ChannelNamePlaceholder".localized()
     )
     private let channelContentTextField: TitledTextField = TitledTextField(
-        title: "채널 이름",
-        placeholder: "채널 이름을 입력하세요 (필수)"
+        title: "ChannelContent".localized(),
+        placeholder: "ChannelContentPlaceholder".localized()
     )
+    
+    override func setView() {
+        super.setView()
+        
+        view.backgroundColor = .gray3
+    }
     
     override func setHierarchy() {
         [navigationView, channelNameTextField, channelContentTextField].forEach {

--- a/BuddyBuddy/Presentation/Home/ViewController/AddChannelViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/AddChannelViewController.swift
@@ -96,9 +96,9 @@ final class AddChannelViewController: BaseViewController {
     
     override func setConstraints() {
         navigationView.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(10)
+            make.top.equalToSuperview()
             make.horizontalEdges.equalToSuperview()
-            make.height.equalTo(44)
+            make.height.equalTo(54)
         }
         channelNameTextField.snp.makeConstraints { make in
             make.top.equalTo(navigationView.snp.bottom).offset(24)

--- a/BuddyBuddy/Presentation/Home/ViewController/AddChannelViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/AddChannelViewController.swift
@@ -20,6 +20,17 @@ final class AddChannelViewController: BaseViewController {
         title: "ChannelContent".localized(),
         placeholder: "ChannelContentPlaceholder".localized()
     )
+    private let okBtn: RoundedButton = {
+        let view = RoundedButton(
+            title: "OK".localized(),
+            bgColor: .gray2,
+            txtColor: .gray1,
+            btnType: .generalBtn
+        )
+        
+        view.isEnabled = false
+        return view
+    }()
     
     override func setView() {
         super.setView()
@@ -28,7 +39,7 @@ final class AddChannelViewController: BaseViewController {
     }
     
     override func setHierarchy() {
-        [navigationView, channelNameTextField, channelContentTextField].forEach {
+        [navigationView, channelNameTextField, channelContentTextField, okBtn].forEach {
             view.addSubview($0)
         }
     }
@@ -48,6 +59,11 @@ final class AddChannelViewController: BaseViewController {
             make.top.equalTo(channelNameTextField.snp.bottom).offset(24)
             make.horizontalEdges.equalToSuperview()
             make.height.equalTo(76)
+        }
+        okBtn.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview().inset(24)
+            make.bottom.equalTo(safeArea).inset(12)
+            make.height.equalTo(44)
         }
     }
 }

--- a/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
@@ -186,13 +186,7 @@ final class HomeViewController: BaseNavigationViewController {
         
         output.showToastMessage
             .drive(with: self) { owner, _ in
-                UIView.animate(withDuration: 1.5, delay: 0.5) {
-                    self.toastMsgLabel.isHidden = false
-                    self.toastMsgLabel.alpha = 0
-                } completion: { _ in
-                    self.toastMsgLabel.alpha = 1
-                    self.toastMsgLabel.isHidden = true
-                }
+                owner.toastMsgLabel.animation()
             }
             .disposed(by: disposeBag)
     }

--- a/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
@@ -121,7 +121,7 @@ final class HomeViewController: BaseNavigationViewController {
     }()
     private let toastMsgLabel: ToastMessageLabel = {
         let view = ToastMessageLabel()
-        view.text = "채널이 생성되었습니다"
+        view.text = ToastMessage.createChannel.localized
         view.isHidden = true
         return view
     }()

--- a/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
@@ -122,6 +122,7 @@ final class HomeViewController: BaseNavigationViewController {
     private let toastMsgLabel: ToastMessageLabel = {
         let view = ToastMessageLabel()
         view.text = "채널이 생성되었습니다"
+        view.isHidden = true
         return view
     }()
     private lazy var datasource = createDataSource()
@@ -181,6 +182,18 @@ final class HomeViewController: BaseNavigationViewController {
                 updateTableViewHeight(sections: sections)
             })
             .drive(channelTableView.rx.items(dataSource: datasource))
+            .disposed(by: disposeBag)
+        
+        output.showToastMessage
+            .drive(with: self) { owner, _ in
+                UIView.animate(withDuration: 1.5, delay: 0.5) {
+                    self.toastMsgLabel.isHidden = false
+                    self.toastMsgLabel.alpha = 0
+                } completion: { _ in
+                    self.toastMsgLabel.alpha = 1
+                    self.toastMsgLabel.isHidden = true
+                }
+            }
             .disposed(by: disposeBag)
     }
     

--- a/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/HomeViewController.swift
@@ -119,6 +119,11 @@ final class HomeViewController: BaseNavigationViewController {
         )
         return view
     }()
+    private let toastMsgLabel: ToastMessageLabel = {
+        let view = ToastMessageLabel()
+        view.text = "채널이 생성되었습니다"
+        return view
+    }()
     private lazy var datasource = createDataSource()
     private var isTableViewBound = false
     private let configureChannelCell = PublishRelay<MyChannel>()
@@ -200,7 +205,7 @@ final class HomeViewController: BaseNavigationViewController {
     }
     
     override func setHierarchy() {
-        [scrollView, floatingBtn].forEach {
+        [scrollView, floatingBtn, toastMsgLabel].forEach {
             view.addSubview($0)
         }
         
@@ -229,6 +234,10 @@ final class HomeViewController: BaseNavigationViewController {
         floatingBtn.snp.makeConstraints { make in
             make.trailing.bottom.equalTo(view.safeAreaLayoutGuide).inset(16)
             make.size.equalTo(50)
+        }
+        toastMsgLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalTo(safeArea).offset(-12)
         }
     }
 }

--- a/BuddyBuddy/Presentation/Home/ViewController/InviteMemberViewController.swift
+++ b/BuddyBuddy/Presentation/Home/ViewController/InviteMemberViewController.swift
@@ -56,6 +56,6 @@ final class InviteMemberViewController: BaseViewController {
     override func setView() {
         super.setView()
         
-        view.backgroundColor = .gray2
+        view.backgroundColor = .gray3
     }
 }

--- a/BuddyBuddy/Presentation/Home/ViewModel/AddChannelViewModel.swift
+++ b/BuddyBuddy/Presentation/Home/ViewModel/AddChannelViewModel.swift
@@ -12,6 +12,11 @@ import RxSwift
 
 final class AddChannelViewModel: ViewModelType {
     private let disposeBag = DisposeBag()
+    private let channelUseCase: ChannelUseCaseInterface
+    
+    init(channelUseCase: ChannelUseCaseInterface) {
+        self.channelUseCase = channelUseCase
+    }
     
     struct Input {
         let nameInputText: Observable<String>
@@ -57,8 +62,23 @@ final class AddChannelViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         input.okBtnTapped
-            .bind(with: self) { owner, _ in
-                // TODO: API 통신
+            .withUnretained(self)
+            .flatMap { _ in
+                return self.channelUseCase.createChannel(
+                    request: AddChannelReqeustDTO(
+                        name: nameInputText.value,
+                        description: contentInputText.value.isEmpty ? nil : contentInputText.value
+                    )
+                )
+            }
+            .bind(with: self) { owner, result in
+                switch result {
+                case .success(let response):
+                    // TODO: 화면 전환
+                    print(response)
+                case .failure(let error):
+                    print(error)
+                }
             }.disposed(by: disposeBag)
         
         return Output(okBtnState: okBtnState.asDriver(onErrorJustReturn: .disable))

--- a/BuddyBuddy/Presentation/Home/ViewModel/AddChannelViewModel.swift
+++ b/BuddyBuddy/Presentation/Home/ViewModel/AddChannelViewModel.swift
@@ -32,7 +32,25 @@ final class AddChannelViewModel: ViewModelType {
             .bind(with: self) { owner, input in
                 nameInputText.accept(input)
                 okBtnState.accept((1...30) ~= input.count ? .enable : .disable)
+                do {
+                    let isValid = try input.isVaild(type: .name)
+                    print("Is valid email: \(isValid)")
+                } catch {
+                    print("Error validating email: \(error)")
+                }
             }.disposed(by: disposeBag)
+        
+//        input.nameInputText
+//            .bind(with: self) { _, input in
+//                nameInputText.accept(input)
+//                do {
+//                    let isValid = try input.isVaild(type: .name)
+//                    okBtnState.accept(isValid ? .enable : .disable)
+//                } catch {
+//                    print("Error validating channel name: \(error)")
+//                    okBtnState.accept(.disable)
+//                }
+//            }.disposed(by: disposeBag)
         
         input.contentInputText
             .bind(to: contentInputText)

--- a/BuddyBuddy/Presentation/Home/ViewModel/AddChannelViewModel.swift
+++ b/BuddyBuddy/Presentation/Home/ViewModel/AddChannelViewModel.swift
@@ -34,28 +34,16 @@ final class AddChannelViewModel: ViewModelType {
         let okBtnState = BehaviorRelay<ButtonState>(value: .disable)
         
         input.nameInputText
-            .bind(with: self) { owner, input in
+            .bind(with: self) { _, input in
                 nameInputText.accept(input)
-                okBtnState.accept((1...30) ~= input.count ? .enable : .disable)
                 do {
                     let isValid = try input.isVaild(type: .name)
-                    print("Is valid email: \(isValid)")
+                    okBtnState.accept(isValid ? .enable : .disable)
                 } catch {
-                    print("Error validating email: \(error)")
+                    print(error)
+                    okBtnState.accept(.disable)
                 }
             }.disposed(by: disposeBag)
-        
-//        input.nameInputText
-//            .bind(with: self) { _, input in
-//                nameInputText.accept(input)
-//                do {
-//                    let isValid = try input.isVaild(type: .name)
-//                    okBtnState.accept(isValid ? .enable : .disable)
-//                } catch {
-//                    print("Error validating channel name: \(error)")
-//                    okBtnState.accept(.disable)
-//                }
-//            }.disposed(by: disposeBag)
         
         input.contentInputText
             .bind(to: contentInputText)

--- a/BuddyBuddy/Presentation/Home/ViewModel/AddChannelViewModel.swift
+++ b/BuddyBuddy/Presentation/Home/ViewModel/AddChannelViewModel.swift
@@ -13,9 +13,15 @@ import RxSwift
 final class AddChannelViewModel: ViewModelType {
     private let disposeBag = DisposeBag()
     private let channelUseCase: ChannelUseCaseInterface
+    private let coordinator: HomeCoordinator
+    weak var delegate: ModalDelegate?
     
-    init(channelUseCase: ChannelUseCaseInterface) {
+    init(
+        channelUseCase: ChannelUseCaseInterface,
+        coordinator: HomeCoordinator
+    ) {
         self.channelUseCase = channelUseCase
+        self.coordinator = coordinator
     }
     
     struct Input {
@@ -62,8 +68,8 @@ final class AddChannelViewModel: ViewModelType {
             .bind(with: self) { owner, result in
                 switch result {
                 case .success(let response):
-                    // TODO: 화면 전환
-                    print(response)
+                    owner.coordinator.dismissVC()
+                    owner.delegate?.dismissModal()
                 case .failure(let error):
                     print(error)
                 }

--- a/BuddyBuddy/Presentation/Home/ViewModel/AddChannelViewModel.swift
+++ b/BuddyBuddy/Presentation/Home/ViewModel/AddChannelViewModel.swift
@@ -1,0 +1,48 @@
+//
+//  AddChannelViewModel.swift
+//  BuddyBuddy
+//
+//  Created by 아라 on 11/27/24.
+//
+
+import Foundation
+
+import RxCocoa
+import RxSwift
+
+final class AddChannelViewModel: ViewModelType {
+    private let disposeBag = DisposeBag()
+    
+    struct Input {
+        let nameInputText: Observable<String>
+        let contentInputText: Observable<String>
+        let okBtnTapped: Observable<Void>
+    }
+    
+    struct Output {
+        let okBtnState: Driver<ButtonState>
+    }
+    
+    func transform(input: Input) -> Output {
+        let nameInputText = BehaviorRelay(value: "")
+        let contentInputText = BehaviorRelay(value: "")
+        let okBtnState = BehaviorRelay<ButtonState>(value: .disable)
+        
+        input.nameInputText
+            .bind(with: self) { owner, input in
+                nameInputText.accept(input)
+                okBtnState.accept((1...30) ~= input.count ? .enable : .disable)
+            }.disposed(by: disposeBag)
+        
+        contentInputText
+            .bind(to: contentInputText)
+            .disposed(by: disposeBag)
+        
+        input.okBtnTapped
+            .bind(with: self) { owner, _ in
+                // TODO: API 통신
+            }.disposed(by: disposeBag)
+        
+        return Output(okBtnState: okBtnState.asDriver(onErrorJustReturn: .disable))
+    }
+}

--- a/BuddyBuddy/Presentation/Home/ViewModel/AddChannelViewModel.swift
+++ b/BuddyBuddy/Presentation/Home/ViewModel/AddChannelViewModel.swift
@@ -34,7 +34,7 @@ final class AddChannelViewModel: ViewModelType {
                 okBtnState.accept((1...30) ~= input.count ? .enable : .disable)
             }.disposed(by: disposeBag)
         
-        contentInputText
+        input.contentInputText
             .bind(to: contentInputText)
             .disposed(by: disposeBag)
         

--- a/BuddyBuddy/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/BuddyBuddy/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -21,6 +21,7 @@ final class HomeViewModel: ViewModelType {
     private let coordinator: HomeCoordinator
     private let channelUseCase: ChannelUseCaseInterface
     private let channelList = BehaviorRelay<MyChannelList>(value: [])
+    private let showToastMessage = PublishRelay<Void>()
     private let playground: Playground
     
     init(
@@ -47,6 +48,7 @@ final class HomeViewModel: ViewModelType {
     struct Output {
         let navigationTitle: Driver<String>
         let updateChannelState: Driver<[ChannelSectionModel]>
+        let showToastMessage: Driver<Void>
     }
     
     func transform(input: Input) -> Output {
@@ -171,7 +173,8 @@ final class HomeViewModel: ViewModelType {
         
         return Output(
             navigationTitle: navigationTitle.asDriver(onErrorJustReturn: "Buddy Buddy"),
-            updateChannelState: updateChannelState.asDriver(onErrorDriveWith: .empty())
+            updateChannelState: updateChannelState.asDriver(onErrorDriveWith: .empty()),
+            showToastMessage: showToastMessage.asDriver(onErrorDriveWith: .empty())
         )
     }
 }
@@ -183,6 +186,7 @@ extension HomeViewModel: ModalDelegate {
                 switch result {
                 case .success(let value):
                     owner.channelList.accept(value)
+                    owner.showToastMessage.accept(())
                 case .failure(let error):
                     print(error)
                 }

--- a/BuddyBuddy/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/BuddyBuddy/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -20,6 +20,7 @@ final class HomeViewModel: ViewModelType {
     
     private let coordinator: HomeCoordinator
     private let channelUseCase: ChannelUseCaseInterface
+    private let channelList = BehaviorRelay<MyChannelList>(value: [])
     private let playground: Playground
     
     init(
@@ -51,7 +52,6 @@ final class HomeViewModel: ViewModelType {
     func transform(input: Input) -> Output {
         let navigationTitle = PublishRelay<String>()
         let updateChannelState = BehaviorRelay<[ChannelSectionModel]>(value: [])
-        let channelList = BehaviorRelay<MyChannelList>(value: [])
         let isChannelFold = BehaviorRelay(value: false)
         
         input.viewWillAppearTrigger
@@ -69,7 +69,7 @@ final class HomeViewModel: ViewModelType {
             .bind(with: self) { owner, result in
                 switch result {
                 case .success(let value):
-                    channelList.accept(value)
+                    owner.channelList.accept(value)
                 case .failure(let error):
                     print(error)
                 }
@@ -92,18 +92,18 @@ final class HomeViewModel: ViewModelType {
                     after: nil
                 )
             }
-            .bind(with: self) { _, result in
+            .bind(with: self) { owner, result in
                 switch result {
                 case .success(let value):
-                    var channels = channelList.value
+                    var channels = owner.channelList.value
                     var current = channels.filter { $0.channelID == value.channelID }
                     current[0].unreadCount = value.count
                     
                     if let index = channels.firstIndex(where: { $0.channelID == value.channelID }),
-                       channels != channelList.value {
+                       channels != owner.channelList.value {
                         channels[index] = current[0]
-                        channelList.accept(channels)
-                     }
+                        owner.channelList.accept(channels)
+                    }
                 case .failure(let error):
                     print(error)
                 }
@@ -148,7 +148,7 @@ final class HomeViewModel: ViewModelType {
         isChannelFold
             .bind(with: self) { owner, isFold in
                 let titleItem = ChannelItem.title(isFold ? .caret : .arrow)
-                let listItem = isFold ? [] : channelList.value.map { ChannelItem.channel($0) }
+                let listItem = isFold ? [] : owner.channelList.value.map { ChannelItem.channel($0) }
                 let addItem = isFold ? [] : [ChannelItem.add("Add Channel".localized())]
                 
                 updateChannelState.accept([.title(item: titleItem),
@@ -173,5 +173,25 @@ final class HomeViewModel: ViewModelType {
             navigationTitle: navigationTitle.asDriver(onErrorJustReturn: "Buddy Buddy"),
             updateChannelState: updateChannelState.asDriver(onErrorDriveWith: .empty())
         )
+    }
+}
+
+extension HomeViewModel: ModalDelegate {
+    func dismissModal() {
+        channelUseCase.fetchMyChannelList(playgroundID: playground.id)
+            .subscribe(with: self) { owner, result in
+                switch result {
+                case .success(let value):
+                    owner.channelList.accept(value)
+                case .failure(let error):
+                    print(error)
+                }
+            } onFailure: { _, error in
+                print(error)
+            } onDisposed: { _ in
+                print("disposed")
+            }
+            .disposed(by: disposeBag)
+
     }
 }

--- a/BuddyBuddy/Resources/Localizable.xcstrings
+++ b/BuddyBuddy/Resources/Localizable.xcstrings
@@ -137,6 +137,23 @@
         }
       }
     },
+    "ChannelCreateSuccess" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Successfully created the channel"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "채널이 생성되었습니다"
+          }
+        }
+      }
+    },
     "ChannelName" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/BuddyBuddy/Resources/Localizable.xcstrings
+++ b/BuddyBuddy/Resources/Localizable.xcstrings
@@ -307,6 +307,23 @@
         }
       }
     },
+    "OK" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확인"
+          }
+        }
+      }
+    },
     "Profile" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/BuddyBuddy/Resources/Localizable.xcstrings
+++ b/BuddyBuddy/Resources/Localizable.xcstrings
@@ -103,6 +103,74 @@
         }
       }
     },
+    "ChannelContent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Content"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "채널 설명"
+          }
+        }
+      }
+    },
+    "ChannelContentPlaceholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please explain the channel (option)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "채널을 설명하세요 (옵션)"
+          }
+        }
+      }
+    },
+    "ChannelName" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Name"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "채널 이름"
+          }
+        }
+      }
+    },
+    "ChannelNamePlaceholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please enter channel name (required)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "채널 이름을 입력하세요 (필수)"
+          }
+        }
+      }
+    },
     "Confirm" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -116,6 +184,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "확인"
+          }
+        }
+      }
+    },
+    "CreateChannel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Channel"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "채널 생성"
           }
         }
       }

--- a/BuddyBuddy/Utils/Enum/ButtonState.swift
+++ b/BuddyBuddy/Utils/Enum/ButtonState.swift
@@ -1,0 +1,13 @@
+//
+//  ButtonState.swift
+//  BuddyBuddy
+//
+//  Created by 아라 on 11/27/24.
+//
+
+import Foundation
+
+enum ButtonState {
+    case disable
+    case enable
+}

--- a/BuddyBuddy/Utils/Enum/RegularExpression.swift
+++ b/BuddyBuddy/Utils/Enum/RegularExpression.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum RegularExpression: String {
-    case name = "^(?=.*[A-Za-z]|(?=.*[가-힣]{1}))(?![0-9]+)[A-Za-z가-힣]{1,30}$"
+    case name = "^(?=.*[A-Za-z]|(?=.*[가-힣]{1}))(?![0-9]{1,30}$)[A-Za-z가-힣0-9\\s]{1,30}$"
     case email = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
     case phone = "01[0-1,7]-[0-9]{3,4}-[0-9]{4}$"
 }

--- a/BuddyBuddy/Utils/Enum/RegularExpression.swift
+++ b/BuddyBuddy/Utils/Enum/RegularExpression.swift
@@ -1,0 +1,14 @@
+//
+//  RegularExpression.swift
+//  BuddyBuddy
+//
+//  Created by 아라 on 11/28/24.
+//
+
+import Foundation
+
+enum RegularExpression: String {
+    case name = "^(?=.*[A-Za-z]|(?=.*[가-힣]{1}))(?![0-9]+)[A-Za-z가-힣]{1,30}$"
+    case email = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+    case phone = "01[0-1,7]-[0-9]{3,4}-[0-9]{4}$"
+}

--- a/BuddyBuddy/Utils/Enum/ToastMessage.swift
+++ b/BuddyBuddy/Utils/Enum/ToastMessage.swift
@@ -1,0 +1,19 @@
+//
+//  ToastMessage.swift
+//  BuddyBuddy
+//
+//  Created by 아라 on 11/29/24.
+//
+
+import Foundation
+
+enum ToastMessage {
+    case createChannel
+    
+    var localized: String {
+        switch self {
+        case .createChannel:
+            return "ChannelCreateSuccess".localized()
+        }
+    }
+}

--- a/BuddyBuddy/Utils/Extension/String+.swift
+++ b/BuddyBuddy/Utils/Extension/String+.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import RegexBuilder
 
 extension String {
     func localized() -> String {
@@ -15,5 +16,16 @@ extension String {
     func toDate(format: BuddyDateFormatter) -> Date? {
         BuddyDateFormatter.standard.dateFormat = format.rawValue
         return BuddyDateFormatter.standard.date(from: self)
+    }
+    
+    func isVaild(type: RegularExpression) throws -> Bool {
+        if #available(iOS 16.0, *) {
+            let regex = try Regex(type.rawValue)
+            return self.wholeMatch(of: regex) != nil
+        } else {
+            let regex = try NSRegularExpression(pattern: type.rawValue)
+            let range = NSRange(location: 0, length: self.utf16.count)
+            return regex.firstMatch(in: self, options: [], range: range) != nil
+        }
     }
 }

--- a/BuddyBuddy/Utils/Extension/UIViewController+.swift
+++ b/BuddyBuddy/Utils/Extension/UIViewController+.swift
@@ -11,4 +11,8 @@ extension UIViewController {
     var safeArea: UILayoutGuide {
         return view.safeAreaLayoutGuide
     }
+    
+    var keyboardLayout: UILayoutGuide {
+        return view.keyboardLayoutGuide
+    }
 }

--- a/BuddyBuddy/Utils/Protocol/ModalDelegate.swift
+++ b/BuddyBuddy/Utils/Protocol/ModalDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  ModalDelegate.swift
+//  BuddyBuddy
+//
+//  Created by 아라 on 11/28/24.
+//
+
+import Foundation
+
+protocol ModalDelegate: AnyObject {
+    func dismissModal()
+}


### PR DESCRIPTION
## 🚀관련 이슈
- close #19 

## ✨작업 내용
- 채널 생성 UI 및 기능 구현
- 모달 뷰 dismiss 시 이전 뷰에서 액션을 처리할 수 있도록 ModalDelegate 프로토콜 구현 - 참고사항1
- 버튼 활성화 상태 처리를 위한 ButtonState 열거형 구현
- 문자열 정규화 처리를 위한 RegularExpression 열거형 구현
- 토스트 메세지 UI 및 열거형 구현 - 참고사항2
- RoundedButton에 updateBtn 메서드 추가 (버튼 활성화 여부에 따른 배경, 글씨 색 변경) - 참고사항3

## 📸 스크린샷
<img  width="30%" src="https://github.com/user-attachments/assets/dceb3f5b-1220-4768-b3c3-a2d66eaf3183"/>

## 📝참고 사항
- 모달로 띄워지는 뷰가 dismiss 될 때 이전 뷰의 viewWillAppear가 호출되지 않기 때문에 Delegate 패턴으로 처리했습니다. 이 때 AddChannelViewModel의 delegate를 HomeViewModel로 설정해주어야하기 때문에 HomeCoordinator에서 homeViewModel를 프로퍼티로 들고있도록 수정하였습니다.
- localized를 위해 리터럴 값을 계속 사용하는게 마음에 들지 않아 ToastMessage라는 열거형을 활용해보았습니당. 필요한 case를 추가하여 사용하시면 돼요!
  localized를 이렇게 카테고리 별로 나눠서 사용하는건 어떤가요? 네비게이션 타이틀, 토스트 메세지, etc.. 처럼요! Enum 파일이 너무 많이 만들어질 것이 우려된다면 localized 관련 enum 하나로 묶어도 좋을 것 같습니다. (2)
- update 하는 메서드를 따로 두면서 setupBtn을 바깥에서 호출 할 일이 없을 것 같은데, private 접근 제어자를 붙이는거 어떻게 생각하시나요?! (3)
- 현재 Request 모델이 DTO 바깥에 위치하고 있습니다! 개인적으로 Data Transfer Object라는 의미에 맞게 Request 또한 DTO의 영역에 포함된다고 생각해요. 그래서 DTO 내부 도메인 별로 Response / Request로 폴더링했는데 이야기 나눠보고 통일하면 좋을 것 같습니다!
- 키보드 대응을 위해 UIViewController에 keyboardLayout라는 프로퍼티를 추가하였습니다. safeArea 처럼 활용하시면 됩니다!
- 첨부한 영상은 custom으로 빼둔 뷰의 수정이 반영되지 않은 상태입니다.

