### PR TITLE
[Chore] 사이드 메뉴 수정

### DIFF
--- a/BuddyBuddy.xcodeproj/project.pbxproj
+++ b/BuddyBuddy.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		C00F90C02CE75EC800B7DD62 /* NetworkLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00F90BF2CE75EC800B7DD62 /* NetworkLogger.swift */; };
 		C0290A7B2D082BA3003B8A5D /* SlideType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0290A7A2D082BA3003B8A5D /* SlideType.swift */; };
+		C0290A7D2D083F1B003B8A5D /* SideMenuHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0290A7C2D083F1B003B8A5D /* SideMenuHandler.swift */; };
 		C02D93BB2CFB47FA003471B9 /* PlaygroundBottomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02D93BA2CFB47FA003471B9 /* PlaygroundBottomView.swift */; };
 		C02D93BD2CFB4DDD003471B9 /* PlaygroundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02D93BC2CFB4DDD003471B9 /* PlaygroundViewController.swift */; };
 		C02D93BF2CFC4EBA003471B9 /* LeftAlignButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02D93BE2CFC4EBA003471B9 /* LeftAlignButton.swift */; };
@@ -255,6 +256,7 @@
 /* Begin PBXFileReference section */
 		C00F90BF2CE75EC800B7DD62 /* NetworkLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkLogger.swift; sourceTree = "<group>"; };
 		C0290A7A2D082BA3003B8A5D /* SlideType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideType.swift; sourceTree = "<group>"; };
+		C0290A7C2D083F1B003B8A5D /* SideMenuHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuHandler.swift; sourceTree = "<group>"; };
 		C02D93BA2CFB47FA003471B9 /* PlaygroundBottomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundBottomView.swift; sourceTree = "<group>"; };
 		C02D93BC2CFB4DDD003471B9 /* PlaygroundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundViewController.swift; sourceTree = "<group>"; };
 		C02D93BE2CFC4EBA003471B9 /* LeftAlignButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LeftAlignButton.swift; path = BuddyBuddy/Presentation/DM/LeftAlignButton.swift; sourceTree = SOURCE_ROOT; };
@@ -1136,6 +1138,7 @@
 				DC9375702CEDC0B900012F43 /* SocketProtocol.swift */,
 				DC9BC0E42CEA0CAB002AF523 /* KeyChainProtocol.swift */,
 				C0A35E0A2CF8A3C600B41E60 /* ModalDelegate.swift */,
+				C0290A7C2D083F1B003B8A5D /* SideMenuHandler.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1717,6 +1720,7 @@
 				C957EA712CE21FD800B62A2A /* SearchItemTableViewCell.swift in Sources */,
 				C02D93C42CFC5F92003471B9 /* PlaygroundList.swift in Sources */,
 				C043982A2D0091A800CCC4A1 /* PlaygroundInfoDTO.swift in Sources */,
+				C0290A7D2D083F1B003B8A5D /* SideMenuHandler.swift in Sources */,
 				C96C729B2CDB289400E0D6CF /* BaseCollectionViewCell.swift in Sources */,
 				DC9375622CEC73B800012F43 /* RealmRepository.swift in Sources */,
 				C91BBC252CE4D25C001EFC70 /* ChangeAdminViewModel.swift in Sources */,

--- a/BuddyBuddy.xcodeproj/project.pbxproj
+++ b/BuddyBuddy.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		C00F90C02CE75EC800B7DD62 /* NetworkLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00F90BF2CE75EC800B7DD62 /* NetworkLogger.swift */; };
+		C0290A7B2D082BA3003B8A5D /* SlideType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0290A7A2D082BA3003B8A5D /* SlideType.swift */; };
 		C02D93BB2CFB47FA003471B9 /* PlaygroundBottomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02D93BA2CFB47FA003471B9 /* PlaygroundBottomView.swift */; };
 		C02D93BD2CFB4DDD003471B9 /* PlaygroundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02D93BC2CFB4DDD003471B9 /* PlaygroundViewController.swift */; };
 		C02D93BF2CFC4EBA003471B9 /* LeftAlignButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02D93BE2CFC4EBA003471B9 /* LeftAlignButton.swift */; };
@@ -253,6 +254,7 @@
 
 /* Begin PBXFileReference section */
 		C00F90BF2CE75EC800B7DD62 /* NetworkLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkLogger.swift; sourceTree = "<group>"; };
+		C0290A7A2D082BA3003B8A5D /* SlideType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideType.swift; sourceTree = "<group>"; };
 		C02D93BA2CFB47FA003471B9 /* PlaygroundBottomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundBottomView.swift; sourceTree = "<group>"; };
 		C02D93BC2CFB4DDD003471B9 /* PlaygroundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundViewController.swift; sourceTree = "<group>"; };
 		C02D93BE2CFC4EBA003471B9 /* LeftAlignButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LeftAlignButton.swift; path = BuddyBuddy/Presentation/DM/LeftAlignButton.swift; sourceTree = SOURCE_ROOT; };
@@ -1282,6 +1284,7 @@
 				C90FEE752CF5D065008819AF /* AlertLiteral.swift */,
 				C02D93C92CFC715F003471B9 /* ActionSheetType.swift */,
 				C97DE2B92CFCAF43000B4E94 /* LoginType.swift */,
+				C0290A7A2D082BA3003B8A5D /* SlideType.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -1777,6 +1780,7 @@
 				C91F672C2CEE425200C84265 /* DefaultUserRepository.swift in Sources */,
 				C9E44A9D2CECC1070044CD5C /* DefaultPlaygroundUseCase.swift in Sources */,
 				DCB9ABB82CFE0645006845CF /* ChannelChattingViewController.swift in Sources */,
+				C0290A7B2D082BA3003B8A5D /* SlideType.swift in Sources */,
 				C96C72992CDAF9EA00E0D6CF /* BaseNavigationViewController.swift in Sources */,
 				C91F67442CF098C900C84265 /* Data+.swift in Sources */,
 				C9F20F542CDB64C10043351E /* AuthViewModel.swift in Sources */,

--- a/BuddyBuddy/Presentation/Base/SideMenu/SlidPresentationController.swift
+++ b/BuddyBuddy/Presentation/Base/SideMenu/SlidPresentationController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SnapKit
 
 final class SlidePresentationController: UIPresentationController {
     private let dimmingView = UIView()
@@ -16,7 +17,7 @@ final class SlidePresentationController: UIPresentationController {
         }
         
         frame.origin = CGPoint(x: 0, y: 0)
-        frame.size.width = frame.size.width
+        frame.size.width *= 0.8
         frame.size.height = frame.size.height
         
         return frame
@@ -53,11 +54,12 @@ final class SlidePresentationController: UIPresentationController {
     
     func setupDimmingViewLayout() {
         dimmingView.alpha = 0.0
+        dimmingView.backgroundColor = .black
         
         containerView?.insertSubview(dimmingView, at: 0)
         
-        dimmingView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+        dimmingView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
         }
     }
     

--- a/BuddyBuddy/Presentation/Base/SideMenu/SlidPresentationController.swift
+++ b/BuddyBuddy/Presentation/Base/SideMenu/SlidPresentationController.swift
@@ -24,7 +24,10 @@ final class SlidePresentationController: UIPresentationController {
         frame.size.width *= 0.8
         frame.size.height = frame.size.height
         
-        frame.origin = CGPoint(x: type == .leading ? 0 : originWidth - frame.size.width, y: 0)
+        frame.origin = CGPoint(
+            x: type == .leading ? 0 : originWidth - frame.size.width,
+            y: 0
+        )
         
         return frame
     }
@@ -55,19 +58,23 @@ final class SlidePresentationController: UIPresentationController {
             return
         }
         
-        coordinator.animate(alongsideTransition: { _ in
-            self.dimmingView.alpha = 0.5
+        coordinator.animate(alongsideTransition: { [weak self] _ in
+            guard let self else { return }
+            dimmingView.alpha = 0.5
         })
     }
     
     override func dismissalTransitionWillBegin() {
         if let coordinator = presentedViewController.transitionCoordinator {
-            coordinator.animate(alongsideTransition: { [weak self] _ in
-                guard let self else { return }
-                dimmingView.alpha = 0.0
-                presentingViewController.view.transform = CGAffineTransform.identity
-                containerView?.layoutIfNeeded()
-            }, completion: nil)
+            coordinator.animate(
+                alongsideTransition: { [weak self] _ in
+                    guard let self else { return }
+                    dimmingView.alpha = 0.0
+                    presentingViewController.view.transform = CGAffineTransform.identity
+                    containerView?.layoutIfNeeded()
+                }, 
+                completion: nil
+            )
         }
     }
     

--- a/BuddyBuddy/Presentation/Base/SideMenu/SlidPresentationController.swift
+++ b/BuddyBuddy/Presentation/Base/SideMenu/SlidPresentationController.swift
@@ -6,11 +6,13 @@
 //
 
 import UIKit
+
 import SnapKit
 
 final class SlidePresentationController: UIPresentationController {
-    private let dimmingView = UIView()
+    let dimmingView = UIView()
     private let type: SlideType
+    weak var sideMenuDelegate: SideMenuHandler?
     
     override var frameOfPresentedViewInContainerView: CGRect {
         guard var frame = containerView?.frame else {
@@ -58,17 +60,6 @@ final class SlidePresentationController: UIPresentationController {
         })
     }
     
-    func setupDimmingViewLayout() {
-        dimmingView.alpha = 0.0
-        dimmingView.backgroundColor = .black
-        
-        containerView?.insertSubview(dimmingView, at: 0)
-        
-        dimmingView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
-        }
-    }
-    
     override func dismissalTransitionWillBegin() {
         if let coordinator = presentedViewController.transitionCoordinator {
             coordinator.animate(alongsideTransition: { [weak self] _ in
@@ -85,5 +76,28 @@ final class SlidePresentationController: UIPresentationController {
         if completed {
             dimmingView.removeFromSuperview()
         }
+    }
+}
+
+extension SlidePresentationController {
+    func setupDimmingViewLayout() {
+        dimmingView.alpha = 0.0
+        dimmingView.backgroundColor = .black
+        
+        containerView?.insertSubview(dimmingView, at: 0)
+        
+        dimmingView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        let tapGesture = UITapGestureRecognizer(
+            target: self,
+            action: #selector(handleTap)
+        )
+        dimmingView.addGestureRecognizer(tapGesture)
+    }
+    
+    @objc func handleTap() {
+        sideMenuDelegate?.dismissNotification()
     }
 }

--- a/BuddyBuddy/Presentation/Base/SideMenu/SlidPresentationController.swift
+++ b/BuddyBuddy/Presentation/Base/SideMenu/SlidPresentationController.swift
@@ -10,25 +10,31 @@ import SnapKit
 
 final class SlidePresentationController: UIPresentationController {
     private let dimmingView = UIView()
+    private let type: SlideType
     
     override var frameOfPresentedViewInContainerView: CGRect {
         guard var frame = containerView?.frame else {
             return .zero
         }
         
-        frame.origin = CGPoint(x: 0, y: 0)
+        let originWidth = frame.width
+        
         frame.size.width *= 0.8
         frame.size.height = frame.size.height
+        
+        frame.origin = CGPoint(x: type == .leading ? 0 : originWidth - frame.size.width, y: 0)
         
         return frame
     }
     
     var transitionCoordinator: UIViewControllerTransitionCoordinator?
     
-    override init(
+    init(
         presentedViewController: UIViewController,
-        presenting presentingViewController: UIViewController?
+        presenting presentingViewController: UIViewController?,
+        type: SlideType
     ) {
+        self.type = type
         super.init(
             presentedViewController: presentedViewController,
             presenting: presentingViewController

--- a/BuddyBuddy/Presentation/Base/SideMenu/SlidePresentationManager.swift
+++ b/BuddyBuddy/Presentation/Base/SideMenu/SlidePresentationManager.swift
@@ -9,17 +9,20 @@ import UIKit
 
 final class SlideInPresentationManager: NSObject {
     var ratio: CGFloat
-    var transition: SlideTransition
+    var transition: SlideTransition?
     var presentationController: UIPresentationController
+    let type: SlideType
     
     init(
         ratio: CGFloat = 0.8,
-        transition: SlideTransition = SlideTransition(),
-        presentationController: UIPresentationController
+        transition: SlideTransition? = nil,
+        presentationController: UIPresentationController,
+        type: SlideType
     ) {
         self.ratio = ratio
-        self.transition = transition
+        self.transition = SlideTransition(type: type)
         self.presentationController = presentationController
+        self.type = type
     }
 }
 
@@ -38,14 +41,14 @@ extension SlideInPresentationManager: UIViewControllerTransitioningDelegate {
     presenting: UIViewController,
     source: UIViewController
   ) -> UIViewControllerAnimatedTransitioning? {
-      transition.isPresenting = true
+      transition?.isPresenting = true
       return transition
   }
 
   func animationController(
     forDismissed dismissed: UIViewController
   ) -> UIViewControllerAnimatedTransitioning? {
-      transition.isPresenting = false
+      transition?.isPresenting = false
       return transition
   }
 }

--- a/BuddyBuddy/Presentation/Base/SideMenu/SlideTransition.swift
+++ b/BuddyBuddy/Presentation/Base/SideMenu/SlideTransition.swift
@@ -12,7 +12,7 @@ final class SlideTransition: NSObject, UIViewControllerAnimatedTransitioning {
     
     func transitionDuration(using transitionContext:
                             (any UIViewControllerContextTransitioning)?) -> TimeInterval {
-        return 0.7
+        return 0.3
     }
     
     func animateTransition(using transitionContext: any UIViewControllerContextTransitioning) {

--- a/BuddyBuddy/Presentation/Base/SideMenu/SlideTransition.swift
+++ b/BuddyBuddy/Presentation/Base/SideMenu/SlideTransition.swift
@@ -9,6 +9,12 @@ import UIKit
 
 final class SlideTransition: NSObject, UIViewControllerAnimatedTransitioning {
     var isPresenting = false
+    private let type: SlideType
+    
+    init(isPresenting: Bool = false, type: SlideType) {
+        self.isPresenting = isPresenting
+        self.type = type
+    }
     
     func transitionDuration(using transitionContext:
                             (any UIViewControllerContextTransitioning)?) -> TimeInterval {
@@ -21,14 +27,23 @@ final class SlideTransition: NSObject, UIViewControllerAnimatedTransitioning {
         else { return }
         
         let containerView = transitionContext.containerView
+        let fullWidth = containerView.bounds.width
         
         let width = toViewController.view.bounds.width
         let height = toViewController.view.bounds.height
+        var initialX: CGFloat = 0.0
+        
+        switch type {
+        case .leading:
+            initialX = -width
+        case .trailing:
+            initialX = width
+        }
         
         if isPresenting {
             containerView.addSubview(toViewController.view)
             toViewController.view.frame = CGRect(
-                x: -width,
+                x: initialX,
                 y: 0,
                 width: width,
                 height: height
@@ -43,9 +58,18 @@ final class SlideTransition: NSObject, UIViewControllerAnimatedTransitioning {
             animations: { [weak self] in
                 guard let self else { return }
                 
+                var translationX: CGFloat =  0.0
+                
+                switch type {
+                case .leading:
+                    translationX = width
+                case .trailing:
+                    translationX = -width
+                }
+                
                 if isPresenting {
                     toViewController.view.transform = CGAffineTransform(
-                        translationX: width,
+                        translationX: translationX,
                         y: 0
                     )
                 } else {

--- a/BuddyBuddy/Presentation/Playground/Coordinator/DefaultPlaygroundCoordinator.swift
+++ b/BuddyBuddy/Presentation/Playground/Coordinator/DefaultPlaygroundCoordinator.swift
@@ -21,11 +21,15 @@ final class DefaultPlaygroundCoordinator: PlaygroundCoordinator {
         useCase: playgroundUseCase
     )
     private let slideType: SlideType = .leading
-    private lazy var presentation = SlidePresentationController(
-        presentedViewController: vc,
-        presenting: nil,
-        type: slideType
-    )
+    private lazy var presentation = {
+        let controller = SlidePresentationController(
+            presentedViewController: vc,
+            presenting: nil,
+            type: slideType
+        )
+        controller.sideMenuDelegate = vc
+        return controller
+    }()
     private lazy var manager = SlideInPresentationManager(
         presentationController: presentation,
         type: slideType

--- a/BuddyBuddy/Presentation/Playground/Coordinator/DefaultPlaygroundCoordinator.swift
+++ b/BuddyBuddy/Presentation/Playground/Coordinator/DefaultPlaygroundCoordinator.swift
@@ -20,11 +20,16 @@ final class DefaultPlaygroundCoordinator: PlaygroundCoordinator {
         coordinator: self,
         useCase: playgroundUseCase
     )
+    private let slideType: SlideType = .leading
     private lazy var presentation = SlidePresentationController(
         presentedViewController: vc,
-        presenting: nil
+        presenting: nil,
+        type: slideType
     )
-    private lazy var manager = SlideInPresentationManager(presentationController: presentation)
+    private lazy var manager = SlideInPresentationManager(
+        presentationController: presentation,
+        type: slideType
+    )
     
     init(
         navigationController: UINavigationController,

--- a/BuddyBuddy/Presentation/Playground/Coordinator/DefaultPlaygroundCoordinator.swift
+++ b/BuddyBuddy/Presentation/Playground/Coordinator/DefaultPlaygroundCoordinator.swift
@@ -20,6 +20,11 @@ final class DefaultPlaygroundCoordinator: PlaygroundCoordinator {
         coordinator: self,
         useCase: playgroundUseCase
     )
+    private lazy var presentation = SlidePresentationController(
+        presentedViewController: vc,
+        presenting: nil
+    )
+    private lazy var manager = SlideInPresentationManager(presentationController: presentation)
     
     init(
         navigationController: UINavigationController,
@@ -30,13 +35,6 @@ final class DefaultPlaygroundCoordinator: PlaygroundCoordinator {
     
     func start() {
         vm.delegate = delegate
-        
-        let presentation = SlidePresentationController(
-            presentedViewController: vc,
-            presenting: nil
-        )
-        
-        let manager = SlideInPresentationManager(presentationController: presentation)
         
         vc.modalPresentationStyle = .custom
         vc.transitioningDelegate = manager

--- a/BuddyBuddy/Presentation/Playground/ViewController/PlaygroundViewController.swift
+++ b/BuddyBuddy/Presentation/Playground/ViewController/PlaygroundViewController.swift
@@ -76,7 +76,7 @@ final class PlaygroundViewController: BaseViewController {
     }
     
     override func setView() {
-        view.backgroundColor = .black.withAlphaComponent(0.5)
+        view.backgroundColor = .clear
     }
     
     override func setHierarchy() {
@@ -89,7 +89,7 @@ final class PlaygroundViewController: BaseViewController {
     
     override func setConstraints() {
         containerView.snp.makeConstraints { make in
-            make.width.equalToSuperview().multipliedBy(0.8)
+            make.width.equalToSuperview()
             make.verticalEdges.leading.equalToSuperview()
         }
         titleLabel.snp.makeConstraints { make in

--- a/BuddyBuddy/Presentation/Playground/ViewController/PlaygroundViewController.swift
+++ b/BuddyBuddy/Presentation/Playground/ViewController/PlaygroundViewController.swift
@@ -41,6 +41,7 @@ final class PlaygroundViewController: BaseViewController {
     }()
     private let bottomView: PlaygroundBottomView = PlaygroundBottomView()
     private let moreBtnTapped = PublishRelay<String>()
+    private let dismiss = PublishRelay<Void>()
     
     init(vm: PlaygroundViewModel) {
         self.vm = vm
@@ -53,7 +54,8 @@ final class PlaygroundViewController: BaseViewController {
             viewWillAppearTrigger: rx.viewWillAppear,
             selectedPlayground: playgroundTableView.rx.modelSelected(Workspace.self).asObservable(),
             moreBtnTapped: moreBtnTapped.asObservable(),
-            addBtnTapped: bottomView.addButton.rx.tap.asObservable()
+            addBtnTapped: bottomView.addButton.rx.tap.asObservable(),
+            dismiss: dismiss.asObservable()
         )
         let output = vm.transform(input: input)
         
@@ -112,5 +114,11 @@ final class PlaygroundViewController: BaseViewController {
     @objc func moreBtnDidTap(_ sender: UIButton) {
         guard let id = sender.accessibilityIdentifier else { return }
         moreBtnTapped.accept(id)
+    }
+}
+
+extension PlaygroundViewController: SideMenuHandler {
+    @objc func dismissNotification() {
+        dismiss.accept(())
     }
 }

--- a/BuddyBuddy/Presentation/Playground/ViewModel/PlaygroundViewModel.swift
+++ b/BuddyBuddy/Presentation/Playground/ViewModel/PlaygroundViewModel.swift
@@ -31,6 +31,7 @@ final class PlaygroundViewModel: ViewModelType {
         let selectedPlayground: Observable<Workspace>
         let moreBtnTapped: Observable<String>
         let addBtnTapped: Observable<Void>
+        let dismiss: Observable<Void>
     }
     
     struct Output {
@@ -95,6 +96,12 @@ final class PlaygroundViewModel: ViewModelType {
         input.addBtnTapped
             .bind(with: self) { owner, _ in
                 // TODO: 생성 화면 전환
+            }
+            .disposed(by: disposeBag)
+        
+        input.dismiss
+            .bind(with: self) { owner, _ in
+                owner.coordinator.dismissVC()
             }
             .disposed(by: disposeBag)
         

--- a/BuddyBuddy/Utils/Enum/SlideType.swift
+++ b/BuddyBuddy/Utils/Enum/SlideType.swift
@@ -1,0 +1,13 @@
+//
+//  SlideType.swift
+//  BuddyBuddy
+//
+//  Created by 아라 on 12/10/24.
+//
+
+import Foundation
+
+enum SlideType {
+    case leading
+    case trailing
+}

--- a/BuddyBuddy/Utils/Protocol/SideMenuHandler.swift
+++ b/BuddyBuddy/Utils/Protocol/SideMenuHandler.swift
@@ -1,0 +1,12 @@
+//
+//  SideMenu.swift
+//  BuddyBuddy
+//
+//  Created by 아라 on 12/10/24.
+//
+
+import Foundation
+
+@objc protocol SideMenuHandler {
+    @objc func dismissNotification()
+}


### PR DESCRIPTION
## 🚀관련 이슈
- close #70 

## ✨작업 내용
- 사이드 메뉴 dismiss 시 설정해둔 애니메이션이 수행되지 않는 문제 해결
- dimmingView 선택 시 dismiss
- 필요한 곳에서 사이드 메뉴를 활용할 수 있도록 enum 타입 추가 (애니메이션 왼->오, 오->왼)

## 📸 스크린샷
<img  width="30%" src="https://github.com/user-attachments/assets/65a201ec-d278-4570-8f61-42d9285b4b63"/>

## 📝참고 사항
- 사이드 메뉴 사용법!
    - 사이드 메뉴로 활용한 ViewController에 SideMenuHandler 채택하기 -> dismidismissNotifications를 구현하여 vm로 dismiss 이벤트를 전달
    - Coordinator에서 SlidePresentationController인스턴스와 SlideInPresentationManager의 인스턴스를 메서드 밖에 선언
        - SlidePresentationController에 sideMenuDelegate를 원하는 vc로 설정
        - SlideType 의 .leading은 왼->오 애니메이션이고 .trailing은 오->왼 애니메이션
    - 화면 전환을 할 때 present 방식으로 해주시고 modalPresentationStyle는 .custom으로, transitioningDelegate는 SlideInPresentationManager의 인스턴스로 설정
    - 